### PR TITLE
Fix some problems in Finduuid.cmake

### DIFF
--- a/cmake/modules/Finduuid.cmake
+++ b/cmake/modules/Finduuid.cmake
@@ -34,7 +34,7 @@ if(NOT UUID_INCLUDE_DIR)
   find_path(UUID_INCLUDE_DIR uuid/uuid.h)
 endif()
 
-if(EXISTS UUID_INCLUDE_DIR)
+if(EXISTS "${UUID_INCLUDE_DIR}")
   set(UUID_INCLUDE_DIRS ${UUID_INCLUDE_DIR})
   set(CMAKE_REQUIRED_INCLUDES ${UUID_INCLUDE_DIRS})
   check_cxx_symbol_exists("uuid_generate_random" "uuid/uuid.h" _uuid_header_only)


### PR DESCRIPTION
* There is some weird CMake behavior where CMake is unable to check for
  the existence of directories in some cases
* If UUID_LIBRARY is given and _uuid_head_only is not set the
  UUID_LIBRARIES variable was never set, leading to undefined symbols in
  libdavix.so