### PR TITLE
Always set UUID_LIBRARIES to UUID_LIBRARY if it's defined

### DIFF
--- a/cmake/modules/Finduuid.cmake
+++ b/cmake/modules/Finduuid.cmake
@@ -44,8 +44,11 @@ if(NOT _uuid_header_only AND NOT UUID_LIBRARY)
   check_library_exists("uuid" "uuid_generate_random" "" _have_libuuid)
   if(_have_libuuid)
     set(UUID_LIBRARY "uuid")
-    set(UUID_LIBRARIES ${UUID_LIBRARY})
   endif()
+endif()
+
+if(UUID_LIBRARY)
+  set(UUID_LIBRARIES ${UUID_LIBRARY})
 endif()
 
 unset(CMAKE_REQUIRED_INCLUDES)


### PR DESCRIPTION
Before, `UUID_LIBRARIES` would only get set to `UUID_LIBRARY` if not already set by the user.

This is an alternative fix to #28.