### PR TITLE
Python 3 compat

### DIFF
--- a/cmake/modules/FindSphinx.cmake
+++ b/cmake/modules/FindSphinx.cmake
@@ -52,7 +52,7 @@ find_program(SPHINX_EXECUTABLE sphinx-build
 if (SPHINX_EXECUTABLE)
   # Try to check Sphinx version by importing Sphinx
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import sphinx; print sphinx.__version__"
+    COMMAND ${PYTHON_EXECUTABLE} -c "import sphinx; print(sphinx.__version__)"
     OUTPUT_VARIABLE SPHINX_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 


### PR DESCRIPTION
The test gives warnings with python 3.
```
-- Found Doxygen: /usr/bin/doxygen (found version "1.8.13") found components:  doxygen missing components:  dot
-- Checking for package 'Sphinx'
-- Found PythonInterp: /usr/bin/python3.6 (found version "3.6.7") 
  File "<string>", line 1
    import sphinx; print sphinx.__version__
                              ^
SyntaxError: invalid syntax
-- Found Sphinx: /usr/bin/sphinx-build  
```
With the PR:
```
-- Checking for package 'Sphinx'
-- Found PythonInterp: /usr/bin/python3.6 (found version "3.6.7")
-- Found Sphinx: /usr/bin/sphinx-build
```
