### PR TITLE
Python Usage Update, devel branch (2019.01.21.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ include/davix/features.hpp
 packaging/davix.spec
 version.cmake
 packaging/debian/changelog
+packaging/repo-manager.py
+test/pywebdav/server/server.py
 .vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,16 @@ project (davix)
 cmake_minimum_required (VERSION 2.6)
 
 #-------------------------------------------------------------------------------
-# Create the genversion.py script
+# Create/configure the python scripts
 #-------------------------------------------------------------------------------
 find_package(PythonInterp REQUIRED)
 set(genversion_script
   ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/genversion.py)
 configure_file(${CMAKE_SOURCE_DIR}/genversion.py.in ${genversion_script})
+configure_file(${CMAKE_SOURCE_DIR}/packaging/repo-manager.py.in
+  ${CMAKE_SOURCE_DIR}/packaging/repo-manager.py)
+configure_file(${CMAKE_SOURCE_DIR}/test/pywebdav/server/server.py.in
+  ${CMAKE_SOURCE_DIR}/test/pywebdav/server/server.py)
 
 #-------------------------------------------------------------------------------
 # Regenerate include/davix/features.hpp and version.cmake at _build_ time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,21 @@ project (davix)
 cmake_minimum_required (VERSION 2.6)
 
 #-------------------------------------------------------------------------------
+# Create the genversion.py script
+#-------------------------------------------------------------------------------
+find_package(PythonInterp REQUIRED)
+set(genversion_script
+  ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/genversion.py)
+configure_file(${CMAKE_SOURCE_DIR}/genversion.py.in ${genversion_script})
+
+#-------------------------------------------------------------------------------
 # Regenerate include/davix/features.hpp and version.cmake at _build_ time
 #-------------------------------------------------------------------------------
 add_custom_target(GenerateVersionInfo ALL DEPENDS Version)
 add_custom_command(
   OUTPUT Version
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/genversion.py --template include/davix/features.hpp.in --out include/davix/features.hpp
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/genversion.py --template version.cmake.in --out version.cmake
+  COMMAND ${genversion_script} --template include/davix/features.hpp.in --out include/davix/features.hpp
+  COMMAND ${genversion_script} --template version.cmake.in --out version.cmake
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -19,7 +27,7 @@ add_custom_command(
 # only regenerates it at compile time.
 #-------------------------------------------------------------------------------
 execute_process(
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/genversion.py --template version.cmake.in --out version.cmake
+  COMMAND ${genversion_script} --template version.cmake.in --out version.cmake
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/genversion.py.in
+++ b/genversion.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!${PYTHON_EXECUTABLE}
 
 ################################################################################
 ## Script to generate version numbers from git tags.                          ##
@@ -229,15 +229,15 @@ def main():
     latest_tag = sh("git describe --abbrev=0 --tags").strip()
 
     replacements = [
-      ["@GIT_SHA1@", commit_hash],
-      ["@GIT_DESCRIBE@", gitDescribe.toString()],
-      ["@GIT_COMMIT_DATE@", git_commit_date],
-      ["@GIT_BRANCH@", branch],
-      ["@VERSION_MAJOR@", softwareVersion.major],
-      ["@VERSION_MINOR@", softwareVersion.minor],
-      ["@VERSION_PATCH@", softwareVersion.patch],
-      ["@VERSION_MINIPATCH@", softwareVersion.miniPatch],
-      ["@VERSION_FULL@", softwareVersion.toString()]
+      ["@GIT_SHA1""@", commit_hash],
+      ["@GIT_DESCRIBE""@", gitDescribe.toString()],
+      ["@GIT_COMMIT_DATE""@", git_commit_date],
+      ["@GIT_BRANCH""@", branch],
+      ["@VERSION_MAJOR""@", softwareVersion.major],
+      ["@VERSION_MINOR""@", softwareVersion.minor],
+      ["@VERSION_PATCH""@", softwareVersion.patch],
+      ["@VERSION_MINIPATCH""@", softwareVersion.miniPatch],
+      ["@VERSION_FULL""@", softwareVersion.toString()]
     ]
 
     inputContents = args.template_string

--- a/packaging/repo-manager.py.in
+++ b/packaging/repo-manager.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!${PYTHON_EXECUTABLE}
 # Author: Georgios Bitzes <georgios.bitzes@cern.ch>
 
 import os, subprocess, sys, inspect, argparse, re, shutil, errno

--- a/test/pywebdav/server/server.py.in
+++ b/test/pywebdav/server/server.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!${PYTHON_EXECUTABLE}
 
 """
 Python WebDAV Server.


### PR DESCRIPTION
For ATLAS I build Davix on a number of platforms, in some cases in not quite standard setups. In one of these setups I build our analysis releases (which build ROOT against an explicitly compiled version of Davix) on a **very** bare bones Ubuntu virtual machine. One that doesn't even have the Python interpreter installed.

This is possible because we build a version of Python as part of our analysis releases. And the build system instructs all externals that need Python for their own build, to build themselves against this version of Python that we are building.

When we moved to davix-0.7.1 I had to tweak our configuration for building Davix in a bit painful way.

```cmake
ExternalProject_Add( Davix
   PREFIX ${CMAKE_BINARY_DIR}
   INSTALL_DIR ${CMAKE_BINARY_DIR}/${ATLAS_PLATFORM}
   URL ${_source}
   URL_MD5 ${_md5}
   CONFIGURE_COMMAND ${CMAKE_BINARY_DIR}/atlas_build_run.sh ${CMAKE_COMMAND}
   -DCMAKE_INSTALL_PREFIX:PATH=${_buildDir}
   -DUUID_INCLUDE_DIR:PATH=${UUID_INCLUDE_DIR}
   -DUUID_LIBRARY:FILEPATH=${UUID_uuid_LIBRARY}
   -DOPENSSL_INCLUDE_DIR:PATH=${OPENSSL_INCLUDE_DIR}
   -DOPENSSL_SSL_LIBRARY:FILEPATH=${OPENSSL_SSL_LIBRARY}
   -DOPENSSL_CRYPTO_LIBRARY:FILEPATH=${OPENSSL_CRYPTO_LIBRARY}
   -DLIB_SUFFIX:STRING= ${_extraArgs} <SOURCE_DIR>
   BUILD_COMMAND ${CMAKE_BINARY_DIR}/atlas_build_run.sh make
   INSTALL_COMMAND ${CMAKE_BINARY_DIR}/atlas_build_run.sh make install
   LOG_CONFIGURE 1 )
```

(The `atlas_build_run.sh` script sets up a correct runtime environment for certain operations, making sure that everything that we've built already, would be in the runtime environment of a given command.)

While this does work, it makes our build configuration inefficient/ugly. (In this setup CMake can only use a single core/process for building Davix...) So I thought I'd see if we could make things a bit better for ATLAS. 😛

I propose to make all scripts that are used during the build/testing/packaging use explicitly the `python` executable found by CMake's `FindPythonInterp.cmake` module. So that it would be convenient to tell the Davix build which Python executable it should be using. I agree that this is not a perfect solution either, but I thought I'd propose it anyway...