### PR TITLE
Adding Docker support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:stretch-slim
+# The default is to build the development branch, set this to a release tag such
+# as R_0_7_2 to get a Docker image for that version.
+ARG DAVIX_RELEASE=devel
+
+RUN \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git ca-certificates cmake g++ build-essential \
+        libxml2-dev libssl-dev uuid-dev python && \
+    rm -rf /var/lib/apt/lists/* && \
+    git clone --branch "$DAVIX_RELEASE" https://github.com/cern-fts/davix.git && \
+    cd davix && \
+    git submodule update --recursive --init && \
+    mkdir build && cd build && \
+    cmake -Wno-dev .. && \
+    make && \
+    make install && \
+    ldconfig && \
+    apt-get purge -y --auto-remove git cmake g++ build-essential \
+        uuid-dev python
+COPY *.sh /usr/local/bin/
+ENTRYPOINT [ "/usr/local/bin/davix.sh" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,40 @@
+# Dockerised davix
+
+Files in this directory enable the creation of a Docker image for davix. The
+Dockerfile is able to build all branches and tags from the repository. The
+branch/tag to build is controlled by the `DAVIX_RELEASE` [build argument].
+
+  [build argument]: https://docs.docker.com/engine/reference/commandline/build#set-build-time-variables---build-arg
+
+## Building
+
+To build this image with the default branch, which is the `devel` branch, run
+the following command. This will create an image called `davix`:
+
+```shell
+docker build -t davix .
+```
+
+To build this image at a given release instead, run a command similar to the
+following one. This will create an image tagged after the name of the release:
+
+```shell
+docker build -t davix:0.7.2 --build-arg DAVIX_RELEASE=R_0_7_2 .
+```
+
+## Running
+
+Given a Docker image called `davix`, you should be able to call the various
+`davix` binaries without their leading `davix-` preamble in the binary name.
+This is achieved through declaring [`davix.sh`] as the [ENTRYPOINT] of the
+image.
+
+  [`davix.sh`]: ./davix.sh
+  [ENTRYPOINT]: https://docs.docker.com/engine/reference/builder/#entrypoint
+
+For example, to call the `davix-ls` binary inside the Docker image `davix`, you
+could run a command similar to the following:
+
+```shell
+docker run -it --rm davix ls --help
+```

--- a/docker/davix.sh
+++ b/docker/davix.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+#####
+# This script provides a sub-command type access to the various davix binaries
+# installed in /usr/local/bin. Instead of calling /usr/local/bin/davix-ls, the
+# script makes it possible to call /usr/local/bin/davix.sh ls with exactly the
+# same set of options. The script is tuned to be used as the entrypoint of the
+# Dockerfile, allowing to run commands such as the following, which is slightly
+# more convenient: docker run -it --rm ... davix ls ...
+#####
+
+cmd=$1
+shift
+
+if [ -x "/usr/local/bin/davix-$cmd" ]; then
+    exec /usr/local/bin/davix-$cmd $@
+else
+    echo "$cmd is an unknown subcommand!" >& 2
+    commands=
+    cd /usr/local/bin
+    for binary in $(ls -1 davix-*); do
+        commands="$commands ${binary#*-}"
+    done
+    echo "Should be one of: $commands" >& 2
+fi


### PR DESCRIPTION
This adds Docker support to davix and allows the creation of easy-to-use Docker images for all existing branches and/or releases. Files needed for Docker support are confined in a new `docker` sub-directory and documentation is provided in the `README.md` file. These files should be enough for automatically creating images at the Docker [hub](https://hub.docker.com/)