### PR TITLE
Fix error handling for proxy delegation

### DIFF
--- a/src/modules/copy/delegation/delegation.cpp
+++ b/src/modules/copy/delegation/delegation.cpp
@@ -249,19 +249,19 @@ std::string DavixDelegation::delegate(Context & context, const std::vector<std::
     std::vector<std::string> errors;
 
     for(size_t i = 0; i < endpoints.size(); i++) {
+        DavixError *delegateError = NULL;
         DAVIX_SLOG(DAVIX_LOG_VERBOSE, DAVIX_LOG_GRID, "Trying out delegation endpoint: {}", endpoints[i]);
 
-        std::string delegationId = DavixDelegation::delegate(context, endpoints[i], params, err);
-        if(!delegationId.empty() && !err) {
+        std::string delegationId = DavixDelegation::delegate(context, endpoints[i], params, &delegateError);
+        if(!delegationId.empty() && !delegateError) {
             // Success
             return delegationId;
         }
 
-        if(err && *err) {
-          errors.emplace_back( (*err)->getErrMsg());
+        if(delegateError) {
+            errors.emplace_back(delegateError->getErrMsg());
+            DavixError::clearError(&delegateError);
         }
-
-        DavixError::clearError(err);
     }
 
     // Error, all delegation endpoints are broken


### PR DESCRIPTION
Delegation code always returns error even in case of successfully delegated proxy. This means TPC always fails in case there is not yet proxy delegated in the past to the storage (e.g. after client refresh its voms proxy). This is causing also a lot of WebDAV TPC transfer failures initiated by FTS, because its credentials are refreshed every hour and storage sited can have multiple diskserver where first transfer with refreshed proxy fails.