### PR TITLE
[DMC-1209]: Transform redirect location relative path into full URI

### DIFF
--- a/src/neon/neonrequest.cpp
+++ b/src/neon/neonrequest.cpp
@@ -432,6 +432,11 @@ int NeonRequest::redirectRequest(DavixError **err) {
         return -1;
     }
 
+    // Fill in host details in case location is relative [DMC-1209]
+    if (location.getProtocol().empty() && location.getHost().empty()) {
+      location = Uri::fromRelativePath(*(_current.get()), location.getString());
+    }
+
     // setup new path & session target
     std::shared_ptr<Uri> old_uri = _current;
     _current= std::shared_ptr<Uri>(new Uri(location));


### PR DESCRIPTION
Would fix the problem described in [DMC-1209](https://its.cern.ch/jira/browse/DMC-1209).

It's a simple solution that addresses the problem in the top-level `NeonRequest::redirectRequest()`.
Perhaps the problem can be solved more elegantly down the line in the `StandaloneRequest` implementations of both NEON or CURL.