### PR TITLE
Really add '\0' after printed X.509 data

### DIFF
--- a/deps/libneon/src/ne_openssl.c
+++ b/deps/libneon/src/ne_openssl.c
@@ -409,7 +409,7 @@ static ne_ssl_certificate *make_chain(STACK_OF(X509) *chain)
             NE_DEBUG(NE_DBG_SSL, "Cert #%d:", n);
             BIO *mem = BIO_new(BIO_s_mem());
             X509_print(mem, cert->subject);
-            BIO_puts(mem, ""); // force \0
+            BIO_write(mem, "", 1); // force \0
             char* cert_str= NULL;
             long  str_size = BIO_get_mem_data(mem, &cert_str);
             if(str_size > 0){


### PR DESCRIPTION
With verbose log level davix prints details about server certificate chain, but it doesn't correctly terminate output data with '\0' character before passing data to "%s" formatting.