### PR TITLE
Swift list collection

### DIFF
--- a/include/davix/params/davix_request_params_types.hpp
+++ b/include/davix/params/davix_request_params_types.hpp
@@ -86,6 +86,15 @@ namespace S3ListingMode{
     };
 }
 
+namespace SwiftListingMode{
+    enum SwiftListingMode{
+        // Full hierarchical listing (depth is 1)
+        Hierarchical,
+        // Semi-hierarchical listing (depth is infinity)
+        SemiHierarchical
+    };
+}
+
 namespace CopyMode{
     enum CopyMode{
         // source push to destination

--- a/include/davix/params/davixrequestparams.hpp
+++ b/include/davix/params/davixrequestparams.hpp
@@ -226,6 +226,12 @@ public:
     /// get listing mode flag for S3 bucket
     S3ListingMode::S3ListingMode getS3ListingMode() const;
 
+    /// set listing mode flag for S3 bucket
+    void setSwiftListingMode(const SwiftListingMode::SwiftListingMode swift_listing_mode);
+
+    /// get listing mode flag for S3 bucket
+    SwiftListingMode::SwiftListingMode getSwiftListingMode() const;
+
     /// set maximum number of key entries return by S3 list object request
     void setS3MaxKey(const unsigned long s3_max_key_entries);
 

--- a/include/davix/params/davixrequestparams.hpp
+++ b/include/davix/params/davixrequestparams.hpp
@@ -226,10 +226,10 @@ public:
     /// get listing mode flag for S3 bucket
     S3ListingMode::S3ListingMode getS3ListingMode() const;
 
-    /// set listing mode flag for S3 bucket
+    /// set listing mode flag for Swift
     void setSwiftListingMode(const SwiftListingMode::SwiftListingMode swift_listing_mode);
 
-    /// get listing mode flag for S3 bucket
+    /// get listing mode flag for Swift
     SwiftListingMode::SwiftListingMode getSwiftListingMode() const;
 
     /// set maximum number of key entries return by S3 list object request

--- a/include/davix/utils/davix_swift_utils.hpp
+++ b/include/davix/utils/davix_swift_utils.hpp
@@ -1,7 +1,7 @@
 /*
  * This File is part of Davix, The IO library for HTTP based protocols
- * Copyright (C) CERN 2013
- * Author: Shiting Long <s.long@fz-juelich.de>
+ * Copyright (C) CERN 2021
+ * Author: Shiting Long <s.long@fz-juelich.de> (Forschungszentrum Juelich)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,7 @@ set(DAVIX_SOURCES
   xml/s3deleteparser.hpp                                 xml/s3deleteparser.cpp
   xml/S3MultiPartInitiationParser.hpp                    xml/S3MultiPartInitiationParser.cpp
   xml/s3propparser.hpp                                   xml/s3propparser.cpp
+  xml/swiftpropparser.hpp                                xml/swiftpropparser.cpp
 
   davixcontext.cpp
   $<TARGET_OBJECTS:LibNeonObjects>

--- a/src/fileops/davmeta.cpp
+++ b/src/fileops/davmeta.cpp
@@ -657,7 +657,6 @@ void swift_start_listing_query(std::unique_ptr<DirHandle> & handle, Context & co
     (void) body;
     dav_ssize_t s_resu;
     DavixError* tmp_err=NULL;
-    bool listing_buckets;
 
     if(params->getSwiftListingMode() == SwiftListingMode::Hierarchical){
         Uri new_url = Swift::swiftUriTransformer(url, params, true);

--- a/src/fileops/davmeta.cpp
+++ b/src/fileops/davmeta.cpp
@@ -695,7 +695,7 @@ void swift_start_listing_query(std::unique_ptr<DirHandle> & handle, Context & co
 
         prop_size = parser.getProperties().size();
         if(s_resu < 2048 && prop_size <1){ // verify request status : if req done + no data -> error
-            throw DavixException(davix_scope_directory_listing_str(), StatusCode::ParsingError, "Invalid server response, not a Swift listing");
+            throw DavixException(davix_scope_directory_listing_str(), StatusCode::ParsingError, "Invalid server response, not a Swift listing or the directory is empty");
         }
         if(timestamp_timeout < time(NULL)){
             throw DavixException(davix_scope_directory_listing_str(), StatusCode::OperationTimeout, "Operation timeout triggered while directory listing");

--- a/src/fileops/davmeta.cpp
+++ b/src/fileops/davmeta.cpp
@@ -663,7 +663,7 @@ void swift_start_listing_query(std::unique_ptr<DirHandle> & handle, Context & co
         Uri new_url = Swift::swiftUriTransformer(url, params, true);
         handle.reset(new DirHandle(new GetRequest(context, new_url, &tmp_err), new SwiftPropParser(Swift::extract_swift_path(url))));
     }
-    else if(params->getS3ListingMode() == S3ListingMode::SemiHierarchical){
+    else if(params->getSwiftListingMode() == SwiftListingMode::SemiHierarchical){
         Uri new_url = Swift::swiftUriTransformer(url, params, false);
         handle.reset(new DirHandle(new GetRequest(context, new_url, &tmp_err), new SwiftPropParser(Swift::extract_swift_path(url))));
     }

--- a/src/fileops/davmeta.cpp
+++ b/src/fileops/davmeta.cpp
@@ -691,12 +691,12 @@ void swift_start_listing_query(std::unique_ptr<DirHandle> & handle, Context & co
     check_file_status(http_req, davix_scope_directory_listing_str());
 
     size_t prop_size = 0;
-    do{ // first entry -> bucket information
+    do{ // first entry -> container information
         s_resu = incremental_listdir_parsing(&http_req, &parser, 2048, davix_scope_directory_listing_str());
 
         prop_size = parser.getProperties().size();
         if(s_resu < 2048 && prop_size <1){ // verify request status : if req done + no data -> error
-            throw DavixException(davix_scope_directory_listing_str(), StatusCode::ParsingError, "Invalid server response, not a S3 listing");
+            throw DavixException(davix_scope_directory_listing_str(), StatusCode::ParsingError, "Invalid server response, not a Swift listing");
         }
         if(timestamp_timeout < time(NULL)){
             throw DavixException(davix_scope_directory_listing_str(), StatusCode::OperationTimeout, "Operation timeout triggered while directory listing");

--- a/src/fileops/davmeta.cpp
+++ b/src/fileops/davmeta.cpp
@@ -651,37 +651,7 @@ bool is_a_container(Uri u) {
     return false;
 }
 
-bool swift_get_next_property(std::unique_ptr<DirHandle> & handle, std::string & name_entry, StatInfo & info){
-    DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, " -> swift_get_next_property");
-    const size_t read_size = 2048;
-
-
-    HttpRequest& req = *(handle->request); // setup env again
-    XMLPropParser& parser = *(handle->parser);
-
-    size_t prop_size = parser.getProperties().size();
-    ssize_t s_resu = read_size;
-
-    while( prop_size == 0
-           && s_resu > 0){ // execute request only if no property are available
-
-        // continue the parsing until one more result
-        s_resu = incremental_listdir_parsing(&req, &parser, read_size, "Swift::listing");
-        prop_size = parser.getProperties().size();
-    }
-
-
-    if(prop_size == 0){
-        return false; // end of the request, end of the story
-    }
-
-    FileProperties & front = parser.getProperties().front();
-    name_entry.swap(front.filename);
-    info = front.info;
-    parser.getProperties().pop_front(); // clean the current element
-    return true;
-}
-
+bool s3_get_next_property(std::unique_ptr<DirHandle> & handle, std::string & name_entry, StatInfo & info);
 
 void swift_start_listing_query(std::unique_ptr<DirHandle> & handle, Context & context, const RequestParams* params, const Uri & url, const std::string & body){
     (void) body;
@@ -740,7 +710,7 @@ bool swift_directory_listing(std::unique_ptr<DirHandle> & handle, Context & cont
     if(handle.get() == NULL){
         swift_start_listing_query(handle, context, params, uri, body);
     }
-    return swift_get_next_property(handle, name_entry, info);
+    return s3_get_next_property(handle, name_entry, info);
 }
 
 

--- a/src/fileops/davmeta.hpp
+++ b/src/fileops/davmeta.hpp
@@ -133,7 +133,7 @@ public:
     virtual StatInfo & statInfo(IOChainContext & iocontext, StatInfo & st_info);
 
     // listing
-    //virtual bool nextSubItem(IOChainContext &iocontext, std::string &entry_name, StatInfo &info);
+    virtual bool nextSubItem(IOChainContext &iocontext, std::string &entry_name, StatInfo &info);
 
 private:
     std::unique_ptr<DirHandle> directoryItem;

--- a/src/params/davixrequestparams.cpp
+++ b/src/params/davixrequestparams.cpp
@@ -90,6 +90,7 @@ struct RequestParamsInternal{
         _recursive_mode(false),
         _s3_listing_mode(S3ListingMode::Hierarchical),
         _s3_max_key_entries(10000),
+        _swift_listing_mode(SwiftListingMode::Hierarchical),
         _ca_path(),
         _x509_data(),
         _idlogpass(),
@@ -140,6 +141,7 @@ struct RequestParamsInternal{
         _recursive_mode(param_private._recursive_mode),
         _s3_listing_mode(param_private._s3_listing_mode),
         _s3_max_key_entries(param_private._s3_max_key_entries),
+        _swift_listing_mode(param_private._swift_listing_mode),
         _ca_path(param_private._ca_path),
         _x509_data(param_private._x509_data),
         _idlogpass(param_private._idlogpass),
@@ -179,6 +181,9 @@ struct RequestParamsInternal{
 
     // s3 bucket listing mode
     S3ListingMode::S3ListingMode _s3_listing_mode;
+
+    // swift listing mode
+    SwiftListingMode::SwiftListingMode _swift_listing_mode;
 
     // Max number of keys returned by a S3 list bucket request
     unsigned long _s3_max_key_entries;
@@ -431,6 +436,14 @@ void RequestParams::setS3ListingMode(const S3ListingMode::S3ListingMode s3_listi
 
 S3ListingMode::S3ListingMode RequestParams::getS3ListingMode() const{
     return d_ptr->_s3_listing_mode;
+}
+
+void RequestParams::setSwiftListingMode(const SwiftListingMode::SwiftListingMode swift_listing_mode){
+    d_ptr->_swift_listing_mode = swift_listing_mode;
+}
+
+SwiftListingMode::SwiftListingMode RequestParams::getSwiftListingMode() const{
+    return d_ptr->_swift_listing_mode;
 }
 
 void RequestParams::setS3MaxKey(const unsigned long s3_max_key_entries){

--- a/src/tools/davix_tool_ls_main.cpp
+++ b/src/tools/davix_tool_ls_main.cpp
@@ -43,7 +43,8 @@ std::string  get_base_listing_options(){
            "\t-r NUMBER_OF_THREADS      List directories's content recursively using multiple threads\n"
            "\t--no-cap:                 Disable size cap on task queue for pending listing operations\n"
            "\t--s3-listing:             S3 bucket listing mode - flat, semi or hierarchical(default)\n"
-           "\t--s3-maxkeys:             Maximum number of entries returns by S3 list bucket request. default: 10000\n";
+           "\t--s3-maxkeys:             Maximum number of entries returns by S3 list bucket request. default: 10000\n"
+           "\t--swift-listing:          Swift listing mode - semi or hierarchical(default)\n";
 }
 
 static std::string help_msg(const std::string & cmd_path){
@@ -241,6 +242,11 @@ int main(int argc, char** argv){
                   // unfortunately s3 defaults max-keys to 1000 and doesn't provide a way to disable the cap, set to large number
                   opts.params.setS3MaxKey(999999999);
 
+                  retcode = listing(opts, fstream, &tmp_err);
+              }
+              else if(opts.params.getRecursiveMode() && (opts.vec_arg[0].compare(0, 5, "swift")==0)) {
+                  // don't need to use -r switch for Swift, just set listing mode to SemiHierarchical and do a normal listing
+                  opts.params.setSwiftListingMode(SwiftListingMode::SemiHierarchical);
                   retcode = listing(opts, fstream, &tmp_err);
               }
               else if(opts.params.getRecursiveMode()){    // dav recursive listing

--- a/src/tools/davix_tool_params.cpp
+++ b/src/tools/davix_tool_params.cpp
@@ -65,6 +65,7 @@ const std::string scope_params = "Davix::Tools::Params";
 #define GCLOUD_CRED_PATH       1027
 #define OS_TOKEN               1028
 #define OS_PROJECT_ID          1029
+#define SWIFT_LISTING_MODE     1030
 
 // LONG OPTS
 
@@ -110,7 +111,8 @@ const std::string scope_params = "Davix::Tools::Params";
 {"s3-listing", required_argument, 0,  S3_LISTING_MODE }, \
 {"s3-maxkeys", required_argument, 0,  S3_MAX_KEYS }, \
 {"no-cap", required_argument, 0, DISABLE_LISTING_CAP}, \
-{"long-list", no_argument, 0,  'l' }
+{"long-list", no_argument, 0,  'l' }, \
+{"swift-listing", required_argument, 0, SWIFT_LISTING_MODE}
 
 #define GET_LONG_OPTIONS \
 {"accepted-retry", required_argument, 0, ACCEPTED_RETRY}, \
@@ -274,6 +276,14 @@ int parse_davix_options_generic(const std::string &opt_filter,
             case S3_MAX_KEYS:
                 p.params.setS3MaxKey(atoi(optarg));
                 break;
+            case SWIFT_LISTING_MODE:
+                {
+                    if(std::string(optarg).compare("hierarchical")==0)
+                        p.params.setSwiftListingMode(SwiftListingMode::Hierarchical);
+                    else if(std::string(optarg).compare("semi")==0)
+                        p.params.setSwiftListingMode(SwiftListingMode::SemiHierarchical);
+                    break;
+                }
             case CAPATH_OPT:
                 p.params.addCertificateAuthorityPath(optarg);
                 break;

--- a/src/utils/davix_swift_utils.cpp
+++ b/src/utils/davix_swift_utils.cpp
@@ -1,7 +1,7 @@
 /*
  * This File is part of Davix, The IO library for HTTP based protocols
- * Copyright (C) CERN 2013
- * Author: Shiting Long <s.long@fz-juelich.de>
+ * Copyright (C) CERN 2021
+ * Author: Shiting Long <s.long@fz-juelich.de> (Forschungszentrum Juelich)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/utils/davix_swift_utils.cpp
+++ b/src/utils/davix_swift_utils.cpp
@@ -87,7 +87,10 @@ Uri swiftUriTransformer(const Uri & original_url, const RequestParams & params, 
     }
     ss << "/";
 
-    ss << extract_swift_container(original_url) << "/";
+    std::string container = extract_swift_container(original_url);
+    if(container.size() != 0){
+        ss << extract_swift_container(original_url) << "/";
+    }
 
     if(!original_url.getPath().empty()){    // there is something after '/', grab it
         std::string tmp = extract_swift_path(original_url);

--- a/src/xml/swiftpropparser.cpp
+++ b/src/xml/swiftpropparser.cpp
@@ -1,0 +1,167 @@
+/*
+ * This File is part of Davix, The IO library for HTTP based protocols
+ * Copyright (C) CERN 2013
+ * Author: Shiting Long <s.long@fz-juelich.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+#include "swiftpropparser.hpp"
+#include <utils/davix_swift_utils.hpp>
+
+#include <stack>
+#include <utils/davix_logger_internal.hpp>
+
+namespace Davix {
+
+const std::string col_prop = "Name";
+const std::string delimiter_prop = "Contents";
+const std::string name_prop = "Key";
+const std::string size_prop = "Size";
+
+const std::string prefix_prop = "Prefix";
+const std::string com_prefix_prop = "CommonPrefixes";
+const std::string listbucketresult_prop = "ListBucketResult";
+const std::string last_modified_prop = "LastModified";
+
+
+struct SwiftPropParser::Internal {
+    std::string current;
+    std::string name;
+    std::string prefix_to_remove;
+    std::deque<FileProperties> props;
+    FileProperties property;
+
+    int start_elem(const std::string &elem){
+        // new tag, clean content;
+        current.clear();
+
+        // if new entry (a directory), clear entry
+        if(StrUtil::compare_ncase("subdir", elem) ==0){
+            property.clear();
+        }
+
+        // if new entry (an object), clear entry
+        if(StrUtil::compare_ncase("object", elem) == 0) {
+            property.clear();
+        }
+
+        return 1;
+    }
+
+    int add_chunk(const std::string & chunk){
+        current.append(chunk);
+        return 0;
+    }
+
+    int end_elem(const std::string &elem){
+        // name
+        if(StrUtil::compare_ncase("name", elem) == 0) {
+            property.filename = current.erase(0, prefix_to_remove.size());
+        }
+
+        // processing a Subdir? Add new dir
+        if( StrUtil::compare_ncase("subdir", elem) ==0){
+            DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "push new common prefix {}", current.c_str());
+            property.info.mode =  0755 | S_IFDIR;
+            property.info.mode &= ~(S_IFREG);
+            props.push_back(property);
+        }
+
+        // object has ended? push new entry
+        if( StrUtil::compare_ncase("object", elem) ==0){
+            DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "push new element {}", elem.c_str());
+            property.info.mode = 0755;
+            props.push_back(property);
+        }
+
+        if( StrUtil::compare_ncase("bytes", elem) ==0){
+            try{
+                dav_size_t size = toType<dav_size_t, std::string>()(current);
+                DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "element size {}", size);
+                property.info.size = size;
+            }catch(...){
+                DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "Unable to parse element size");
+            }
+        }
+
+        if( StrUtil::compare_ncase("last_modified", elem) ==0){
+            try{
+                time_t mtime = S3::s3TimeConverter(current);
+                DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "element LastModified {}", current);
+                property.info.mtime = mtime;
+                property.info.ctime = mtime;
+            }catch(...){
+                DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "Unable to parse element LastModified");
+            }
+        }
+
+        return 0;
+    }
+};
+
+
+SwiftPropParser::SwiftPropParser() : d_ptr(new Internal())
+{
+    SwiftPropParser("");
+}
+
+SwiftPropParser::SwiftPropParser(std::string prefix) : d_ptr(new Internal())
+{
+    if(prefix[prefix.size() - 1] != '/') {
+        d_ptr->prefix_to_remove = prefix + "/";
+    }
+    else {
+        d_ptr->prefix_to_remove = prefix;
+    }
+
+    if(d_ptr->prefix_to_remove == "/") {
+        d_ptr->prefix_to_remove = "";
+    }
+}
+
+SwiftPropParser::~SwiftPropParser(){ }
+
+
+int SwiftPropParser::parserStartElemCb(int parent, const char *nspace, const char *name, const char **atts){
+    /*(void) parent;
+    (void) nspace;
+    (void) atts;
+    return d_ptr->start_elem(std::string(name)); */
+
+    return d_ptr->start_elem(std::string(name));
+}
+
+int SwiftPropParser::parserCdataCb(int state, const char *cdata, size_t len){
+    /*(void) state;
+    (void) len;
+    return d_ptr->add_chunk(std::string(cdata, len));*/
+    //std::cout << "cdata: " << std::string(cdata, len) << std::endl;
+    return d_ptr->add_chunk(std::string(cdata, len));
+}
+
+int SwiftPropParser::parserEndElemCb(int state, const char *nspace, const char *name){
+    /*(void) state;
+    (void) nspace;
+    return d_ptr->end_elem(std::string(name));*/
+
+    return d_ptr->end_elem(std::string(name));
+}
+
+std::deque<FileProperties> & SwiftPropParser::getProperties(){
+    return d_ptr->props;
+}
+}

--- a/src/xml/swiftpropparser.cpp
+++ b/src/xml/swiftpropparser.cpp
@@ -1,7 +1,7 @@
 /*
  * This File is part of Davix, The IO library for HTTP based protocols
- * Copyright (C) CERN 2013
- * Author: Shiting Long <s.long@fz-juelich.de>
+ * Copyright (C) CERN 2021
+ * Author: Shiting Long <s.long@fz-juelich.de> (Forschungszentrum Juelich)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/xml/swiftpropparser.cpp
+++ b/src/xml/swiftpropparser.cpp
@@ -79,7 +79,7 @@ struct SwiftPropParser::Internal {
         }
 
         // processing a Subdir? Add new dir
-        if( StrUtil::compare_ncase("subdir", elem) ==0){
+        if( StrUtil::compare_ncase("subdir", elem) == 0 && !property.filename.empty()){
             DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "push new common prefix {}", current.c_str());
             property.info.mode =  0755 | S_IFDIR;
             property.info.mode &= ~(S_IFREG);
@@ -88,14 +88,14 @@ struct SwiftPropParser::Internal {
         }
 
         // object has ended? push new entry
-        if( StrUtil::compare_ncase("object", elem) ==0){
+        if( StrUtil::compare_ncase("object", elem) == 0){
             DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "push new element {}", elem.c_str());
             property.info.mode = 0755;
             props.push_back(property);
             property.clear();
         }
 
-        if( StrUtil::compare_ncase("bytes", elem) ==0){
+        if( StrUtil::compare_ncase("bytes", elem) == 0){
             try{
                 dav_size_t size = toType<dav_size_t, std::string>()(current);
                 DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "element size {}", size);
@@ -105,7 +105,7 @@ struct SwiftPropParser::Internal {
             }
         }
 
-        if( StrUtil::compare_ncase("last_modified", elem) ==0){
+        if( StrUtil::compare_ncase("last_modified", elem) == 0){
             try{
                 time_t mtime = S3::s3TimeConverter(current);
                 DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "element LastModified {}", current);
@@ -117,7 +117,7 @@ struct SwiftPropParser::Internal {
         }
 
         // listing containers? push new entry
-        if( StrUtil::compare_ncase("container", elem) ==0 && !property.filename.empty()){
+        if( StrUtil::compare_ncase("container", elem) == 0 && !property.filename.empty()){
             DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "push new element {}", elem.c_str());
             property.info.mode =  0755 | S_IFDIR;
             property.info.mode &= ~(S_IFREG);

--- a/src/xml/swiftpropparser.cpp
+++ b/src/xml/swiftpropparser.cpp
@@ -59,6 +59,11 @@ struct SwiftPropParser::Internal {
             property.clear();
         }
 
+        // if a new container, clear entry
+        if(StrUtil::compare_ncase("container", elem) == 0) {
+            property.clear();
+        }
+
         return 1;
     }
 
@@ -79,6 +84,7 @@ struct SwiftPropParser::Internal {
             property.info.mode =  0755 | S_IFDIR;
             property.info.mode &= ~(S_IFREG);
             props.push_back(property);
+            property.clear();
         }
 
         // object has ended? push new entry
@@ -86,6 +92,7 @@ struct SwiftPropParser::Internal {
             DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "push new element {}", elem.c_str());
             property.info.mode = 0755;
             props.push_back(property);
+            property.clear();
         }
 
         if( StrUtil::compare_ncase("bytes", elem) ==0){
@@ -107,6 +114,14 @@ struct SwiftPropParser::Internal {
             }catch(...){
                 DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "Unable to parse element LastModified");
             }
+        }
+
+        // listing containers? push new entry
+        if( StrUtil::compare_ncase("container", elem) ==0 && !property.filename.empty()){
+            DAVIX_SLOG(DAVIX_LOG_TRACE, DAVIX_LOG_XML, "push new element {}", elem.c_str());
+            property.info.mode =  0755 | S_IFDIR;
+            property.info.mode &= ~(S_IFREG);
+            props.push_back(property);
         }
 
         return 0;

--- a/src/xml/swiftpropparser.cpp
+++ b/src/xml/swiftpropparser.cpp
@@ -122,7 +122,7 @@ SwiftPropParser::SwiftPropParser() : d_ptr(new Internal())
 SwiftPropParser::SwiftPropParser(std::string prefix) : d_ptr(new Internal())
 {
     if(prefix[prefix.size() - 1] != '/') {
-        d_ptr->prefix_to_remove = prefix + "/";
+        d_ptr->prefix_to_remove = prefix.erase(0,1) + "/";
     }
     else {
         d_ptr->prefix_to_remove = prefix;

--- a/src/xml/swiftpropparser.hpp
+++ b/src/xml/swiftpropparser.hpp
@@ -1,7 +1,7 @@
 /*
  * This File is part of Davix, The IO library for HTTP based protocols
- * Copyright (C) CERN 2013
- * Author: Shiting Long <s.long@fz-juelich.de>
+ * Copyright (C) CERN 2021
+ * Author: Shiting Long <s.long@fz-juelich.de> (Forschungszentrum Juelich)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/xml/swiftpropparser.hpp
+++ b/src/xml/swiftpropparser.hpp
@@ -1,0 +1,57 @@
+/*
+ * This File is part of Davix, The IO library for HTTP based protocols
+ * Copyright (C) CERN 2013
+ * Author: Shiting Long <s.long@fz-juelich.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+#ifndef DAVIX_SWIFTPROPPARSER_HPP
+#define DAVIX_SWIFTPROPPARSER_HPP
+
+#include <deque>
+
+#include <davix_internal.hpp>
+#include <xml/davxmlparser.hpp>
+#include <utils/davix_fileproperties.hpp>
+#include <string.h>
+
+namespace Davix{
+
+class SwiftPropParser :  public XMLPropParser
+{
+public:
+    struct Internal;
+    SwiftPropParser();
+    SwiftPropParser(std::string swift_prefix);
+    virtual ~SwiftPropParser();
+
+    virtual std::deque<FileProperties> & getProperties();
+
+
+protected:
+    virtual int parserStartElemCb(int parent, const char *nspace, const char *name, const char **atts);
+    virtual int parserCdataCb(int state, const char *cdata, size_t len);
+    virtual int parserEndElemCb(int state, const char *nspace, const char *name);
+
+
+private:
+    std::unique_ptr<Internal> d_ptr;
+};
+
+}
+
+#endif //DAVIX_SWIFTPROPPARSER_HPP

--- a/test/functional/davix-tester.cpp
+++ b/test/functional/davix-tester.cpp
@@ -366,6 +366,10 @@ void countfiles(TestcaseHandler &handler, const RequestParams &params, const Uri
         int i = 0;
 
         do {
+            // workaround for Swift, discard the first entry which is the directory created before
+            if(params.getProtocol() == RequestProtocol::Swift && i == 0){
+                it.next();
+            }
             i++;
         } while(it.next());
 
@@ -390,6 +394,10 @@ void listing(TestcaseHandler &handler, const RequestParams &params, const Uri ur
 
         int i = 0;
         do {
+            // workaround for Swift, discard the first entry which is the directory created before
+            if(params.getProtocol() == RequestProtocol::Swift && i == 0){
+                it.next();
+            }
             i++;
             std::string name = it.name();
 


### PR DESCRIPTION
Add listing function for Swift. 

One can use command 'davix-ls <url> --osprojectid <id> --ostoken <token>' for listing, optionally, '--swift-listing' can be used to list directories in semi-hierarchical or hierarchical way.