### PR TITLE
Swift write from provider

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(DAVIX_SOURCES
   fileops/httpiovec.hpp                                  fileops/httpiovec.cpp
   fileops/iobuffmap.hpp                                  fileops/iobuffmap.cpp
   fileops/S3IO.hpp                                       fileops/S3IO.cpp
+  fileops/SwiftIO.hpp                                    fileops/SwiftIO.cpp
 
                                                          hooks/davix_hooks.cpp
 
@@ -78,7 +79,7 @@ set(DAVIX_SOURCES
 
   davixcontext.cpp
   $<TARGET_OBJECTS:LibNeonObjects>
-        fileops/SwiftIO.hpp fileops/SwiftIO.cpp)
+)
 
 set(DAVIX_INTERNAL_INCLUDES
   ${OPENSSL_INCLUDE_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,7 @@ set(DAVIX_SOURCES
 
   davixcontext.cpp
   $<TARGET_OBJECTS:LibNeonObjects>
-)
+        fileops/SwiftIO.hpp fileops/SwiftIO.cpp)
 
 set(DAVIX_INTERNAL_INCLUDES
   ${OPENSSL_INCLUDE_DIR}

--- a/src/fileops/SwiftIO.cpp
+++ b/src/fileops/SwiftIO.cpp
@@ -117,13 +117,13 @@ void SwiftIO::commitInlineChunks(IOChainContext & iocontext, const std::vector<P
     Uri url(iocontext._uri);
 
     size_t iterNum = 0;
-    size_t remaining = props.size();
     size_t propBegin = 1;
     size_t propEnd = MaxManifestSegments;
+
     std::string lastEtag;
     std::string path = url.getPath();
 
-    while(remaining > 0){
+    while(propBegin <= propEnd){
         // generate a multipart manifest in json
         std::ostringstream manifest;
         manifest << "[";
@@ -143,13 +143,12 @@ void SwiftIO::commitInlineChunks(IOChainContext & iocontext, const std::vector<P
         }
         manifest << "]";
 
-        remaining -= propEnd - propBegin + 1;
         propBegin = propEnd + 1;
-        propEnd = std::min(propEnd + MaxManifestSegments - 1, propEnd + remaining);
+        propEnd = std::min(propEnd + MaxManifestSegments - 1, props.size());
 
         // upload the manifest
         DavixError * tmp_err=NULL;
-        if(remaining > 0) {
+        if(propBegin <= propEnd) {
             url.setPath(path + "-" + std::to_string(iterNum));
         } else{
             url.setPath(path);

--- a/src/fileops/SwiftIO.cpp
+++ b/src/fileops/SwiftIO.cpp
@@ -1,0 +1,178 @@
+/*
+ * This File is part of Davix, The IO library for HTTP based protocols
+ * Copyright (C) CERN 2021
+ * Author: Shiting Long <s.long@fz-juelich.de> (Forschungszentrum Juelich)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+#include "SwiftIO.hpp"
+#include <core/ContentProvider.hpp>
+#include <utils/davix_logger_internal.hpp>
+#include <utils/davix_swift_utils.hpp>
+
+
+namespace Davix{
+
+static bool is_swift_operation(IOChainContext & context){
+    if(context._reqparams->getProtocol() == RequestProtocol::Swift) {
+        return true;
+    }
+
+    return false;
+}
+
+static bool should_use_swift_multipart(IOChainContext & context, dav_size_t size) {
+    bool is_swift = is_swift_operation(context);
+
+    if (!is_swift) return false;
+
+    return size > (1024 * 2); // 512 MB
+}
+
+static std::string extract_swift_object_path(Uri url) {
+    return url.getPath();
+}
+
+SwiftIO::SwiftIO() {
+
+}
+
+SwiftIO::~SwiftIO() {
+
+}
+
+static dav_size_t fillBufferWithProviderData(std::vector<char> &buffer, const dav_size_t maxChunkSize, ContentProvider &provider) {
+    dav_size_t written = 0u;
+    dav_size_t remaining = maxChunkSize;
+
+    while(true) {
+        dav_ssize_t bytesRead = provider.pullBytes(buffer.data(), remaining);
+        if(bytesRead < 0) {
+            throw DavixException(davix_scope_io_buff(), StatusCode::InvalidFileHandle, fmt::format("Error when reading from callback: {}", bytesRead));
+        }
+
+        remaining -= bytesRead;
+        written += bytesRead;
+
+        if(bytesRead == 0) {
+            DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "Reached data provider EOF, received 0 bytes, even though asked for {}", remaining);
+            break; // EOF
+        }
+
+        if(remaining == 0) {
+            DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "Data provider buffer has been filled");
+            break; // buffer is full
+        }
+    }
+
+    DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "Retrieved {} bytes from data provider", written);
+    return written;
+}
+
+std::string SwiftIO::writeChunk(IOChainContext &iocontext, const char *buff, dav_size_t size, int partNumber) {
+    Uri url(iocontext._uri);
+    url.setPath(url.getPath() + "/" + std::to_string(partNumber));
+
+    DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "writing chunk #{} with size {}", partNumber, size);
+
+    DavixError * tmp_err=NULL;
+    PutRequest req(iocontext._context, url, &tmp_err);
+    checkDavixError(&tmp_err);
+
+    req.setParameters(iocontext._reqparams);
+    req.setRequestBody(buff, size);
+    req.executeRequest(&tmp_err);
+    if(!tmp_err && httpcodeIsValid(req.getRequestCode()) == false){
+        httpcodeToDavixError(req.getRequestCode(), davix_scope_io_buff(),
+                             "write error: ", &tmp_err);
+    }
+    DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "write result size {}", size);
+    checkDavixError(&tmp_err);
+
+    std::string etag;
+    if(!req.getAnswerHeader("Etag", etag)) {
+        DavixError::setupError(&tmp_err, "Swift::MultiPart", StatusCode::InvalidServerResponse, "Unable to retrieve chunk Etag, necessary when committing chunks");
+    }
+
+    DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "chunk #{} written successfully, etag: {}", partNumber, etag);
+    return etag;
+}
+
+void SwiftIO::commitChunks(IOChainContext & iocontext, const std::vector<Prop> &props) {
+    Uri url(iocontext._uri);
+
+    DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "committing {} chunks", props.size());
+
+    std::ostringstream payload;
+    payload << "[";
+    for(size_t i = 1; i <= props.size(); i++) {
+        payload << "{";
+        payload << "\"path\":\"" << extract_swift_object_path(url) << "/" << i << "\"}";
+        if(i != props.size()) {
+            payload << ',';
+        }
+    }
+    payload << "]";
+    //std::cout << payload.str() << std::endl;
+
+    DavixError * tmp_err=NULL;
+    url.addQueryParam("multipart-manifest", "put");
+    PutRequest req(iocontext._context, url, &tmp_err);
+    req.addHeaderField("Content-Type", "application/json");
+    req.setParameters(iocontext._reqparams);
+    req.setRequestBody(payload.str());
+    req.executeRequest(&tmp_err);
+
+    if(!tmp_err && httpcodeIsValid(req.getRequestCode()) == false){
+        httpcodeToDavixError(req.getRequestCode(), davix_scope_io_buff(),
+                             "write error: ", &tmp_err);
+    }
+    checkDavixError(&tmp_err);
+}
+
+dav_ssize_t SwiftIO::writeFromProvider(IOChainContext & iocontext, ContentProvider &provider) {
+    if(!should_use_swift_multipart(iocontext, provider.getSize())) {
+        CHAIN_FORWARD(writeFromProvider(iocontext, provider));
+    }
+
+    DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "Initiating large file upload towards {} to upload file with size {}", iocontext._uri, provider.getSize());
+
+    size_t remaining = provider.getSize();
+    const dav_size_t MAX_CHUNK_SIZE = 1024 * 1; // 256 MB
+
+    std::vector<char> buffer;
+    buffer.resize(std::min(MAX_CHUNK_SIZE, (dav_size_t) provider.getSize()) + 10);
+
+    std::vector<Prop> props;
+
+    size_t partNumber = 0;
+
+    while(remaining > 0) {
+        size_t toRead = std::min( (dav_size_t) provider.getSize(), MAX_CHUNK_SIZE);
+        DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "SwiftIO write: toRead from cb {}", toRead);
+
+        dav_size_t bytesRead = fillBufferWithProviderData(buffer, MAX_CHUNK_SIZE, provider);
+        if(bytesRead == 0) break; // EOF
+
+        partNumber++;
+        props.emplace_back(writeChunk(iocontext, buffer.data(), bytesRead, partNumber), bytesRead);
+    }
+
+    commitChunks(iocontext, props);
+}
+
+}

--- a/src/fileops/SwiftIO.cpp
+++ b/src/fileops/SwiftIO.cpp
@@ -40,6 +40,11 @@ static bool should_use_swift_multipart(IOChainContext & context, dav_size_t size
 
     if (!is_swift) return false;
 
+    if(context._uri.fragmentParamExists("forceMultiPart")) {
+
+        return true;
+    }
+
     return size > (1024 * 1024 * 512); // 512 MB
 }
 
@@ -113,6 +118,7 @@ void SwiftIO::commitChunks(IOChainContext & iocontext, const std::vector<Prop> &
 
     DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "committing {} chunks", props.size());
 
+    // generate a multipart manifest in json
     std::ostringstream manifest;
     manifest << "[";
     for(size_t i = 1; i <= props.size(); i++) {

--- a/src/fileops/SwiftIO.hpp
+++ b/src/fileops/SwiftIO.hpp
@@ -36,25 +36,17 @@ public:
     // write from content provider
     virtual dav_ssize_t writeFromProvider(IOChainContext & iocontext, ContentProvider &provider);
 
-    //void performUgrS3MultiPart(IOChainContext & iocontext, const std::string &posturl, const std::string &pluginId, ContentProvider &provider, DavixError **err);
-
 private:
 
-    // Returns uploadId
-    //std::string initiateMultipart(IOChainContext & iocontext);
-    //std::string initiateMultipart(IOChainContext & iocontext, const Uri &url);
-
-    //DynafedUris retrieveDynafedUris(IOChainContext & iocontext, const std::string &uploadId, const std::string &pluginId, size_t nchunks);
-
-    // Given the upload id, write the given chunk. Return object ETag,
+    // Write the given chunk. Return object properties (etag + size_bytes),
     // necessary to commit upload.
     std::string writeChunk(IOChainContext & iocontext, const char* buff, dav_size_t size, int partNumber);
-    //std::string writeChunk(IOChainContext & iocontext, const char* buff, dav_size_t size, const Uri &uri, int partNumber);
 
 
-    // Given upload id and last chunk, commit chunks
+    // Given the properties (etag + size_bytes) of the segments, commit chunks
     void commitChunks(IOChainContext & iocontext, const std::vector<Prop> &props);
-    //void commitChunks(IOChainContext & iocontext,  const Uri &uri, const std::vector<std::string> &etags);
+    // Commit chunks in a inline manner if the number of segments has exceeded the limit defined by max_manifest_segments
+    void commitInlineChunks(IOChainContext & iocontext, const std::vector<Prop> &props, const size_t MaxManifestSegments);
 };
 
 }

--- a/src/fileops/SwiftIO.hpp
+++ b/src/fileops/SwiftIO.hpp
@@ -1,0 +1,62 @@
+/*
+ * This File is part of Davix, The IO library for HTTP based protocols
+ * Copyright (C) CERN 2021
+ * Author: Shiting Long <s.long@fz-juelich.de> (Forschungszentrum Juelich)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+*/
+
+#ifndef DAVIX_SWIFTIO_HPP
+#define DAVIX_SWIFTIO_HPP
+
+#include <fileops/httpiochain.hpp>
+
+namespace Davix{
+
+typedef std::pair <std::string, int> Prop;
+
+class SwiftIO : public HttpIOChain {
+public:
+    SwiftIO();
+    ~SwiftIO();
+
+    // write from content provider
+    virtual dav_ssize_t writeFromProvider(IOChainContext & iocontext, ContentProvider &provider);
+
+    //void performUgrS3MultiPart(IOChainContext & iocontext, const std::string &posturl, const std::string &pluginId, ContentProvider &provider, DavixError **err);
+
+private:
+
+    // Returns uploadId
+    //std::string initiateMultipart(IOChainContext & iocontext);
+    //std::string initiateMultipart(IOChainContext & iocontext, const Uri &url);
+
+    //DynafedUris retrieveDynafedUris(IOChainContext & iocontext, const std::string &uploadId, const std::string &pluginId, size_t nchunks);
+
+    // Given the upload id, write the given chunk. Return object ETag,
+    // necessary to commit upload.
+    std::string writeChunk(IOChainContext & iocontext, const char* buff, dav_size_t size, int partNumber);
+    //std::string writeChunk(IOChainContext & iocontext, const char* buff, dav_size_t size, const Uri &uri, int partNumber);
+
+
+    // Given upload id and last chunk, commit chunks
+    void commitChunks(IOChainContext & iocontext, const std::vector<Prop> &props);
+    //void commitChunks(IOChainContext & iocontext,  const Uri &uri, const std::vector<std::string> &etags);
+};
+
+}
+
+#endif //DAVIX_SWIFTIO_HPP

--- a/src/fileops/chain_factory.cpp
+++ b/src/fileops/chain_factory.cpp
@@ -27,6 +27,7 @@
 #include "iobuffmap.hpp"
 #include "AzureIO.hpp"
 #include "S3IO.hpp"
+#include "SwiftIO.hpp"
 
 namespace Davix{
 
@@ -43,7 +44,7 @@ HttpIOChain& ChainFactory::instanceChain(const CreationFlags & flags, HttpIOChai
         elem = elem->add(new HttpIOBuffer());
     }
 
-    elem->add(new S3IO())->add(new AzureIO())->add(new HttpIO())->add(new HttpIOVecOps());
+    elem->add(new S3IO())->add(new SwiftIO())->add(new AzureIO())->add(new HttpIO())->add(new HttpIOVecOps());
     return c;
 }
 

--- a/src/tools/davix_tool_put_main.cpp
+++ b/src/tools/davix_tool_put_main.cpp
@@ -115,7 +115,7 @@ static int populateTaskQueue(Context& c, const Tool::OptParams & opts, std::stri
         if((strcmp(de->d_name, ".")) && (strcmp(de->d_name, ".."))){    // ignore "." and ".." entries
             if(stat(((src_path+de->d_name).c_str()), &st) == 0){    // check if entry is file or directory
                 if(S_ISDIR(st.st_mode)){    // is directory
-                    if(opts.params.getProtocol() != RequestProtocol::AwsS3){    // if protocol is S3, don't need make collection (not heirarchical)
+                    if(opts.params.getProtocol() != RequestProtocol::AwsS3){    // if protocol is S3, don't need make collection (not hierarchical)
                         ret = tryMakeCollection(c, opts, Uri::join(dst_path, de->d_name));
                         if(ret <0)
                             return ret;
@@ -168,7 +168,7 @@ static int prePutCheck(Tool::OptParams & opts, DavixError** err){
         DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CORE, "Creating threadpool");
         DavixThreadPool tp(&tq, opts.threadpool_size);
 
-        if(opts.params.getProtocol() != RequestProtocol::AwsS3){    // if protocol is S3, don't need make collection (not heirarchical)
+        if(opts.params.getProtocol() != RequestProtocol::AwsS3 || opts.params.getProtocol() != RequestProtocol::Swift){    // if protocol is S3 or Swift, don't need make collection (not hierarchical)
             ret = tryMakeCollection(c, opts, opts.vec_arg[1]);
             if(ret <0)
                 return ret;


### PR DESCRIPTION
Add uploading files function for Swift, with multipart upload considered. 

One can use 'davix-put local/file/path swifts://.. --ostoken $token --osprojectid $id' to upload local file to Swift, and use '-r' option to upload a directory of files to Swift. One can use fragment '#forceMultipart' to make use of [multipart upload](https://docs.openstack.org/swift/latest/overview_large_objects.html#module-swift.common.middleware.slo) supported by Swift.

Multipart upload is used for files > 512MB. In this case, a large file is uploaded in a set of segments of maximum size 256MB. The default maximum segment number in one multipart manifest in Swift is 1000, hence, large files that exceed the 1000 limit in segments will be uploaded in an inline manner (where the file is represented by manifests within one manifest).
