### PR TITLE
add command checksum to davix-tester

### DIFF
--- a/src/fileops/davmeta.hpp
+++ b/src/fileops/davmeta.hpp
@@ -123,9 +123,6 @@ public:
 
     //TODO: IMPLEMENT METAOPS BELOW
 
-    // Swift + HTTP checksum computation
-    //virtual void checksum(IOChainContext & iocontext, std::string & checksm, const std::string & chk_algo);
-
     // move/rename resource
     //virtual void move(IOChainContext & iocontext, const std::string & target_url);
 


### PR DESCRIPTION
The handling of checksum for S3 can be used for Swift, thus, no additional function is added for Swift.

But the davix-tester does not have the option to verify the checksum, so I added a function there to get the checksum of a file. I also added a 'fulltest-swift' option for Swift, as is the case with S3/Azure.