### PR TITLE
Swift move

### DIFF
--- a/include/davix/params/davix_request_params_types.hpp
+++ b/include/davix/params/davix_request_params_types.hpp
@@ -136,6 +136,11 @@ typedef std::string OSToken;
 ///
 typedef std::string OSProjectID;
 
+///
+/// \brief string for Swift Account
+///
+typedef  std::string SwiftAccount;
+
 #ifdef __DAVIX_HAS_STD_FUNCTION
 
     ///

--- a/include/davix/params/davixrequestparams.hpp
+++ b/include/davix/params/davixrequestparams.hpp
@@ -220,6 +220,18 @@ public:
     ///
     const OSProjectID & getOSProjectID() const;
 
+    ///
+    /// \brief set the Swift account used for Swift authentication
+    /// \param the Swift account
+    ///
+    void setSwiftAccount(const SwiftAccount & account);
+
+    ///
+    /// \brief get the Swift account used for Swift authentication
+    /// \return the Swift account
+    ///
+    const SwiftAccount & getSwiftAccount() const;
+
     /// set listing mode flag for S3 bucket
     void setS3ListingMode(const S3ListingMode::S3ListingMode s3_listing_mode);
 

--- a/src/fileops/davmeta.hpp
+++ b/src/fileops/davmeta.hpp
@@ -121,10 +121,8 @@ public:
     SwiftMetaOps();
     virtual ~SwiftMetaOps();
 
-    //TODO: IMPLEMENT METAOPS BELOW
-
     // move/rename resource
-    //virtual void move(IOChainContext & iocontext, const std::string & target_url);
+    virtual void move(IOChainContext & iocontext, const std::string & target_url);
 
     // get statInfo
     virtual StatInfo & statInfo(IOChainContext & iocontext, StatInfo & st_info);

--- a/src/params/davixrequestparams.cpp
+++ b/src/params/davixrequestparams.cpp
@@ -104,6 +104,7 @@ struct RequestParamsInternal{
         _gcloud_creds(),
         _os_token(),
         _os_project_id(),
+        _swift_account(),
         ops_timeout(),
         connexion_timeout(),
         agent_string(default_agent),
@@ -155,6 +156,7 @@ struct RequestParamsInternal{
         _gcloud_creds(param_private._gcloud_creds),
         _os_token(param_private._os_token),
         _os_project_id(param_private._os_project_id),
+        _swift_account(param_private._swift_account),
         ops_timeout(),
         connexion_timeout(),
         agent_string(param_private.agent_string),
@@ -205,6 +207,7 @@ struct RequestParamsInternal{
     gcloud::Credentials _gcloud_creds;
     OSToken _os_token;
     OSProjectID _os_project_id;
+    SwiftAccount _swift_account;
 
     // timeout management
     struct timespec ops_timeout;
@@ -428,6 +431,14 @@ void RequestParams::setOSProjectID(const OSProjectID &id) {
 
 const OSProjectID & RequestParams::getOSProjectID() const {
     return d_ptr->_os_project_id;
+}
+
+void RequestParams::setSwiftAccount(const SwiftAccount &account) {
+    d_ptr->_swift_account = account;
+}
+
+const SwiftAccount & RequestParams::getSwiftAccount() const {
+    return d_ptr->_swift_account;
 }
 
 void RequestParams::setS3ListingMode(const S3ListingMode::S3ListingMode s3_listing_mode){

--- a/src/tools/davix_tool_params.cpp
+++ b/src/tools/davix_tool_params.cpp
@@ -66,6 +66,7 @@ const std::string scope_params = "Davix::Tools::Params";
 #define OS_TOKEN               1028
 #define OS_PROJECT_ID          1029
 #define SWIFT_LISTING_MODE     1030
+#define SWIFT_ACCOUNT          1031
 
 // LONG OPTS
 
@@ -100,7 +101,8 @@ const std::string scope_params = "Davix::Tools::Params";
 {"gcloud-creds", required_argument, 0, GCLOUD_CRED_PATH}, \
 {"insecure", no_argument, 0,  'k' }, \
 {"ostoken", required_argument, 0, OS_TOKEN}, \
-{"osprojectid", required_argument, 0, OS_PROJECT_ID}
+{"osprojectid", required_argument, 0, OS_PROJECT_ID}, \
+{"swiftaccount", required_argument, 0, SWIFT_ACCOUNT}
 
 #define REQUEST_LONG_OPTIONS \
 {"request",  required_argument, 0,  'X' }, \
@@ -146,6 +148,7 @@ OptParams::OptParams() :
     aws_alternate(false),
     os_token(),
     os_project_id(),
+    swift_account(),
     pres_flag(0),
     shell_flag(0),
     has_input_file(false),
@@ -340,6 +343,10 @@ int parse_davix_options_generic(const std::string &opt_filter,
                 break;
             case OS_PROJECT_ID:
                 p.os_project_id = optarg;
+                strncpy(optarg, "", strlen(optarg));
+                break;
+            case SWIFT_ACCOUNT:
+                p.swift_account = optarg;
                 strncpy(optarg, "", strlen(optarg));
                 break;
             case 'l':
@@ -605,6 +612,7 @@ std::string get_common_options(){
             "\t--gcloud-creds PATH:      Path to gcloud json credentials\n"
             "\t--ostoken TOKEN:          Swift authentication: Openstack token\n"
             "\t--osprojectid:            Swift authentication: Openstack project ID\n"
+            "\t--swiftaccount:           Alternative Swift authentication: Swift account\n"
             ;
 }
 

--- a/src/tools/davix_tool_params.hpp
+++ b/src/tools/davix_tool_params.hpp
@@ -83,6 +83,8 @@ struct OptParams{
     std::string os_token;
     // openstack project id for swift
     std::string os_project_id;
+    // swift account
+    std::string swift_account;
     // presentation flag
     int pres_flag;
     // shell flags

--- a/src/tools/davix_tool_util.cpp
+++ b/src/tools/davix_tool_util.cpp
@@ -124,9 +124,10 @@ int configureAuth(OptParams & opts){
     }
 
     // setup swift creds
-    if(opts.os_token.empty() == false && opts.os_project_id.empty() == false) {
+    if(opts.os_token.empty() == false && (opts.os_project_id.empty() == false || opts.swift_account.empty() == false)) {
         opts.params.setOSToken(opts.os_token);
         opts.params.setOSProjectID(opts.os_project_id);
+        opts.params.setSwiftAccount(opts.swift_account);
         opts.params.setProtocol(RequestProtocol::Swift);
     }
 

--- a/src/utils/davix_swift_utils.cpp
+++ b/src/utils/davix_swift_utils.cpp
@@ -60,11 +60,11 @@ std::string extract_swift_container(const Uri & uri) {
 Uri signURI(const RequestParams & params, const Uri & url) {
     Uri signed_url(url);
 
-    if(!params.getOSProjectID().empty()) {
-        signed_url.setPath("/v1/AUTH_" + params.getOSProjectID() + url.getPath());
-    }
-    else if (!params.getSwiftAccount().empty()) {
+    if(!params.getSwiftAccount().empty()) {
         signed_url.setPath("/v1/" + params.getSwiftAccount() + url.getPath());
+    }
+    else if (!params.getOSProjectID().empty()) {
+        signed_url.setPath("/v1/AUTH_" + params.getOSProjectID() + url.getPath());
     }
     return signed_url;
 }

--- a/src/utils/davix_swift_utils.cpp
+++ b/src/utils/davix_swift_utils.cpp
@@ -63,6 +63,9 @@ Uri signURI(const RequestParams & params, const Uri & url) {
     if(!params.getOSProjectID().empty()) {
         signed_url.setPath("/v1/AUTH_" + params.getOSProjectID() + url.getPath());
     }
+    else if (!params.getSwiftAccount().empty()) {
+        signed_url.setPath("/v1/" + params.getSwiftAccount() + url.getPath());
+    }
     return signed_url;
 }
 


### PR DESCRIPTION
1. Added move function for Swift.
2. Added option --swift-account in addition to --os-project-id for accessing Swift. This is because Swift API makes use of URL format /v1/{account}/{container}/{object}. When Keystone auth is configured for Swift, which is usually the case, the {account} part is AUTH_{os_project_id}. In the case that another auth system is configured, users need a Swift account to access Swift. Davix should be able to support this scenario as well.