### PR TITLE
Fix return value of `HttpIO::readFull`

### DIFF
--- a/src/fileops/iobuffmap.cpp
+++ b/src/fileops/iobuffmap.cpp
@@ -166,7 +166,7 @@ dav_ssize_t HttpIO::readFull(IOChainContext & iocontext, std::vector<char> & buf
     }
 
     checkDavixError(&tmp_err);
-    return (ret>0)?total:-1;
+    return (ret>=0)?total:-1;
 }
 
 


### PR DESCRIPTION
When the end of the file is reached, `ret` will be 0 and the total number
of bytes read should be returned.

Potential fix for #69.