### PR TITLE
Fix spelling errors reported by lintian

### DIFF
--- a/include/davix/auth/davixauth.hpp
+++ b/include/davix/auth/davixauth.hpp
@@ -61,7 +61,7 @@ private:
 #ifdef __DAVIX_HAS_STD_FUNCTION
 
 ///
-/// std::function for advanced authentification with client cert X509
+/// std::function for advanced authentication with client cert X509
 ///
 /// @param info : Session info, contains information about server requesting the certificate
 /// @param cert : Client side credential to provide
@@ -72,7 +72,7 @@ typedef std::function<int  (const SessionInfo & info, X509Credential& cert)> aut
 
 
 ///
-/// callback for advanced authentification with client cert X509
+/// callback for advanced authentication with client cert X509
 /// @param userdata : user defined data
 /// @param info : Session info, contains information about server requesting the certificate
 /// @param cert : Client side credential to provide
@@ -82,7 +82,7 @@ typedef int (*authCallbackClientCertX509)(void* userdata, const SessionInfo & in
 
 
 ///
-/// callback for advanced authentification with client cert X509
+/// callback for advanced authentication with client cert X509
 /// @param userdata : user defined data
 /// @param info : Session info, contains information about server requesting the certificate
 /// @param login : login to use

--- a/include/davix/file/davposix.hpp
+++ b/include/davix/file/davposix.hpp
@@ -280,7 +280,7 @@ public:
       @param buffer buffer to fill
       @param count maximum number of bytes to read
       @param err Davix Error report
-      @return the size of data or a negative value if an error occured
+      @return the size of data or a negative value if an error occurred
 
       @snippet example_code_snippets.cpp read
      */
@@ -297,7 +297,7 @@ public:
       @param count maximum number of bytes to read
       @param offset  offset to use
       @param err Davix Error report
-      @return the size of data or a negative value if an error occured
+      @return the size of data or a negative value if an error occurred
 
       @snippet example_code_snippets.cpp pread
      */
@@ -318,7 +318,7 @@ public:
       @param count maximum number of bytes to write
       @param offset  offset to use
       @param err Davix Error report
-      @return the size of data written or a negative value if an error occured
+      @return the size of data written or a negative value if an error occurred
 
       @snippet example_code_snippets.cpp pwrite
      */
@@ -363,7 +363,7 @@ public:
       @param buf buffer with the write content
       @param count number of bytes to write
       @param err Davix Error report
-      @return the size of the written data or a negative value if an error occured
+      @return the size of the written data or a negative value if an error occurred
 
       @snippet example_code_snippets.cpp write
      */

--- a/include/davix/params/davixrequestparams.hpp
+++ b/include/davix/params/davixrequestparams.hpp
@@ -63,7 +63,7 @@ struct RequestParamsInternal;
 /// @brief Main container for Davix request options
 ///
 /// RequestParams hold the davix request options :
-/// authentification parameters, timeouts, user-agents,...
+/// authentication parameters, timeouts, user-agents,...
 /// A Requestparams object can be shared between several Request
 class DAVIX_EXPORT RequestParams
 {

--- a/include/davix/status/davixstatusrequest.hpp
+++ b/include/davix/status/davixstatusrequest.hpp
@@ -95,7 +95,10 @@ enum Code {
     AlreadyRunning = 0x00d,
 
     /// Authentication Error
-    AuthenticationError= 0x00e,
+    AuthenticationError = 0x00e,
+
+    /// Misspelled - kept for backward compatibility
+    AuthentificationError = AuthenticationError,
 
     /// Wrong Login and/or Password
     LoginPasswordError = 0x00f,
@@ -159,8 +162,10 @@ enum Code {
     EnvVarNotSet = 0x28,
 
     /// Undefined error
-    UnknowError = 0x100
+    UnknownError = 0x100,
 
+    /// Misspelled - kept for backward compatibility
+    UnknowError = UnknownError
 
 };
 
@@ -338,7 +343,7 @@ void checkDavixError(DavixError** err);
     }catch(std::exception & e){ \
         DavixError::setupError(err, " ", StatusCode::SystemError, std::string("System Error ").append(e.what())); \
     }catch(...){ \
-        DavixError::setupError(err, " ", StatusCode::UnknowError, std::string("Unknow Error .... report this")); \
+        DavixError::setupError(err, " ", StatusCode::UnknownError, std::string("Unknown Error .... report this")); \
     }
 
 
@@ -388,9 +393,6 @@ DAVIX_EXPORT void errno_to_davix_exception(int errno_code, const std::string & s
 // Warning: Deprecated symbols, do not use anymore
 // /////////////////////////////////////////////////
 // Deprecated, do not use, API compability only
-namespace StatusCode{
-const Code AuthentificationError = AuthenticationError;
-}
 
 typedef enum StatusCode::Code davix_status_t;
 

--- a/src/auth/davix_openssl.cpp
+++ b/src/auth/davix_openssl.cpp
@@ -45,7 +45,7 @@ void opensslErrorMapper(const std::string & msg, DavixError** err){
     char buff_err[255] ={0};
     e= ERR_get_error();
     if(e == 0){
-        DavixError::setupError(err, openssl_scope, StatusCode::UnknowError, "No Error reported by OpenSSL");
+        DavixError::setupError(err, openssl_scope, StatusCode::UnknownError, "No Error reported by OpenSSL");
         return;
     }
 
@@ -105,7 +105,7 @@ ne_ssl_client_cert *SSL_X509_Pem_Read(const std::string & pkeyfile_str, const st
 
 
     if( pkeyfile ==NULL || credfile ==NULL || ((in = BIO_new(BIO_s_file())) == NULL)){
-        DavixError::setupError(err, openssl_scope, StatusCode::UnknowError, "init error");
+        DavixError::setupError(err, openssl_scope, StatusCode::UnknownError, "init error");
         return NULL;
     }
 

--- a/src/backend/StandaloneNeonRequest.cpp
+++ b/src/backend/StandaloneNeonRequest.cpp
@@ -148,47 +148,47 @@ static void neon_error_mapper(int ne_status, StatusCode::Code & code, std::strin
   switch(ne_status){
     case NE_OK: {
       code = StatusCode::OK;
-      str= "Status Ok";
+      str = "Status Ok";
       break;
     }
     case NE_LOOKUP: {
       code = StatusCode::NameResolutionFailure;
-      str= "Domain name resolution failed";
+      str = "Domain name resolution failed";
       break;
     }
     case NE_AUTH: {
       code = StatusCode::AuthenticationError;
-      str=  "Authentification failed on server";
+      str = "Authentication failed on server";
       break;
     }
     case NE_PROXYAUTH: {
       code = StatusCode::AuthenticationError;
-      str=  "Authentification failed on proxy";
+      str = "Authentication failed on proxy";
       break;
     }
     case NE_CONNECT: {
       code = StatusCode::ConnectionProblem;
-      str= "Could not connect to server";
+      str = "Could not connect to server";
       break;
     }
     case NE_TIMEOUT: {
       code = StatusCode::ConnectionTimeout;
-      str= "Connection timed out";
+      str = "Connection timed out";
       break;
     }
     case NE_FAILED: {
       code = StatusCode::SessionCreationError;
-      str=  "The precondition failed";
+      str = "The precondition failed";
       break;
     }
     case NE_RETRY: {
       code = StatusCode::RedirectionNeeded;
-      str= "Retry Request";
+      str = "Retry Request";
       break;
     }
     default: {
-      code= StatusCode::UnknowError;
-      str= "Unknow Error from libneon";
+      code = StatusCode::UnknownError;
+      str = "Unknown Error from libneon";
     }
   }
 

--- a/src/curl/StandaloneCurlRequest.cpp
+++ b/src/curl/StandaloneCurlRequest.cpp
@@ -262,7 +262,7 @@ static Status curlCodeToStatus(CURLcode code) {
       return Status(davix_scope_http_request(), StatusCode::OperationTimeout, ss.str());
     }
     default: {
-      return Status(davix_scope_http_request(), StatusCode::UnknowError, ss.str());
+      return Status(davix_scope_http_request(), StatusCode::UnknownError, ss.str());
     }
   }
 }

--- a/src/fileops/davix_reliability_ops.cpp
+++ b/src/fileops/davix_reliability_ops.cpp
@@ -161,7 +161,7 @@ int davix_get_metalink_url( Context & c, const Uri & uri,
       if (tmp_err)
         throw DavixException(davix_scope_meta(), tmp_err->getStatus(), tmp_err->getErrMsg());
       else
-        throw DavixException(davix_scope_meta(), Davix::StatusCode::UnknowError, "Unknown error");
+        throw DavixException(davix_scope_meta(), Davix::StatusCode::UnknownError, "Unknown error");
     }
 
     HeaderVec headers;
@@ -319,7 +319,7 @@ ReturnType autoRetryExecutor(HttpIOChain & chain, IOChainContext & io_context, E
             }
         }catch(...){
             DAVIX_SLOG(DAVIX_LOG_VERBOSE, DAVIX_LOG_CHAIN, "Operation failure: Unknown Error");
-            throw DavixException(davix_scope_io_buff(), StatusCode::UnknowError, fmt::format("Unrecoverable error from IOChain on {}", u));
+            throw DavixException(davix_scope_io_buff(), StatusCode::UnknownError, fmt::format("Unrecoverable error from IOChain on {}", u));
         }
         ++retry;
         sleep(retry_delay);

--- a/src/fileops/davmeta.cpp
+++ b/src/fileops/davmeta.cpp
@@ -197,7 +197,7 @@ dav_ssize_t incremental_listdir_parsing(HttpRequest* req, XMLPropParser * parser
         buffer[ret]= '\0';
         parser->parseChunk(buffer, ret);
     }else{
-        throw DavixException(scope, StatusCode::UnknowError, "Unknow readSegment error");
+        throw DavixException(scope, StatusCode::UnknownError, "Unknown readSegment error");
     }
 
     return ret;
@@ -602,7 +602,7 @@ static void swiftStatMapper(Context& context, const RequestParams* params, const
                 throw DavixException(scope, StatusCode::FileNotFound, "Not a file or directory");
             }
             else if (ret < 0) {
-                throw DavixException(scope, StatusCode::UnknowError, "Unknown readSegment error");
+                throw DavixException(scope, StatusCode::UnknownError, "Unknown readSegment error");
             }
             checkDavixError(&tmp_err);
 
@@ -633,7 +633,7 @@ static void swiftStatMapper(Context& context, const RequestParams* params, const
                 st_info.mode |= S_IFDIR;
         }
         else if(code == 500){
-            throw DavixException(scope, StatusCode::UnknowError, "Internal Server Error triggered while attempting to get Swift object's stats");
+            throw DavixException(scope, StatusCode::UnknownError, "Internal Server Error triggered while attempting to get Swift object's stats");
         }
     }
     checkDavixError(&tmp_err);
@@ -777,7 +777,7 @@ void SwiftMetaOps::move(IOChainContext & iocontext, const std::string & target_u
     else {
         std::stringstream str;
         str << "Received code " << req.getRequestCode() << " when trying to copy file - will not perform deletion";
-        throw DavixException(scope, StatusCode::UnknowError, str.str());
+        throw DavixException(scope, StatusCode::UnknownError, str.str());
     }
 }
 
@@ -881,7 +881,7 @@ void S3MetaOps::move(IOChainContext & iocontext, const std::string & target_url)
     else {
         std::stringstream str;
         str << "Received code " << req.getRequestCode() << " when trying to copy file - will not perform deletion";
-        throw DavixException(scope, StatusCode::UnknowError, str.str());
+        throw DavixException(scope, StatusCode::UnknownError, str.str());
     }
 }
 
@@ -978,7 +978,7 @@ void s3StatMapper(Context& context, const RequestParams* params, const Uri & uri
             }
         }
         else if(code == 500)
-            throw DavixException(scope, StatusCode::UnknowError, "Internal Server Error triggered while attempting to get S3 object's stats");
+            throw DavixException(scope, StatusCode::UnknownError, "Internal Server Error triggered while attempting to get S3 object's stats");
     }
     checkDavixError(&tmp_err);
 }

--- a/src/fileops/httpiovec.cpp
+++ b/src/fileops/httpiovec.cpp
@@ -64,7 +64,7 @@ void HttpIoVecSetupErrorMultiPartTooLong(DavixError** err){
 }
 
 void HttpIoVecSetupErrorMultiPartBoundary(const std::string & boundary, DavixError** err){
-    DavixError::setupError(err, HttpIoVec_scope(), StatusCode::InvalidServerResponse, std::string("Invalid boundary for multipart http reponse :").append(boundary));
+    DavixError::setupError(err, HttpIoVec_scope(), StatusCode::InvalidServerResponse, std::string("Invalid boundary for multipart http response :").append(boundary));
 }
 
 void HttpIoVecSetupErrorMultiPartSize( DavixError** err, dav_off_t req_offset, dav_size_t req_size, dav_off_t ans_offset, dav_size_t ans_size){

--- a/src/libs/alibxx/typeconv/typeconv.hpp
+++ b/src/libs/alibxx/typeconv/typeconv.hpp
@@ -34,14 +34,14 @@ inline void check_overflow_integral(Integral val, int errcode){
     if( (val == std::numeric_limits<Integral>::min() || val ==std::numeric_limits<Integral>::max())
          && ( errcode == ERANGE || errcode == EINVAL)){
          errno =0;
-         throw TypeConvException("Overflow during type converstion from string to integral value");
+         throw TypeConvException("Overflow during type conversion from string to integral value");
     }
 }
 
 inline void check_strto_error(char * end_str, const std::string & str){
     if( str.size() ==0 || *end_str != '\0'){
          errno =0;
-         throw TypeConvException("Invalid type converstion from string to integral value");
+         throw TypeConvException("Invalid type conversion from string to integral value");
     }
 }
 
@@ -53,7 +53,7 @@ template<typename T, typename S>
 struct toType{
     T operator()(const S & val){
             (void) val;
-            throw TypeConvException("Invalid type converstion: no specialization");
+            throw TypeConvException("Invalid type conversion: no specialization");
     }
 
 };
@@ -152,7 +152,7 @@ struct toType<std::string, S>{
         ss.str("");
         ss << val;
         if(ss.fail()){
-            throw TypeConvException("Invalid type converstion from string to ");
+            throw TypeConvException("Invalid type conversion from string to ");
         }
         return ret.str();
     }

--- a/src/modules/copy/copy.cpp
+++ b/src/modules/copy/copy.cpp
@@ -326,7 +326,7 @@ void DavixCopyInternal::copy(const Uri &src, const Uri &dst,
         else if (responseStatus >= 300) {
             std::ostringstream msg;
             msg << "Could not COPY. Unknown error code: " << responseStatus;
-            DavixError::setupError(error, COPY_SCOPE, StatusCode::UnknowError,
+            DavixError::setupError(error, COPY_SCOPE, StatusCode::UnknownError,
                                    msg.str());
         }
     }
@@ -441,7 +441,7 @@ void DavixCopyInternal::monitorPerformanceMarkers(Davix::HttpRequest *request,
     }
 
     if(!clearOutcome && !(*error)) {
-        Davix::DavixError::setupError(error, COPY_SCOPE, StatusCode::UnknowError,
+        Davix::DavixError::setupError(error, COPY_SCOPE, StatusCode::UnknownError,
             std::string("Connection terminated abruptly; Status of TPC request unknown"));
     }
 }

--- a/src/neon/neonrequest.cpp
+++ b/src/neon/neonrequest.cpp
@@ -62,39 +62,39 @@ void neon_generic_error_mapper(int ne_status, StatusCode::Code & code, std::stri
     switch(ne_status){
         case NE_OK:
             code = StatusCode::OK;
-            str= "Status Ok";
+            str = "Status Ok";
             break;
         case NE_LOOKUP:
-             code = StatusCode::NameResolutionFailure;
-             str= "Domain name resolution failed";
-             break;
+            code = StatusCode::NameResolutionFailure;
+            str = "Domain name resolution failed";
+            break;
         case NE_AUTH:
             code = StatusCode::AuthenticationError;
-            str = "Authentification failed on server";
+            str = "Authentication failed on server";
             break;
         case NE_PROXYAUTH:
             code = StatusCode::AuthenticationError;
-            str=  "Authentification failed on proxy";
+            str = "Authentication failed on proxy";
             break;
         case NE_CONNECT:
             code = StatusCode::ConnectionProblem;
-            str= "Could not connect to server";
+            str = "Could not connect to server";
             break;
         case NE_TIMEOUT:
             code = StatusCode::ConnectionTimeout;
-            str= "Connection timed out";
+            str = "Connection timed out";
             break;
         case NE_FAILED:
             code = StatusCode::SessionCreationError;
-            str=  "The precondition failed";
+            str = "The precondition failed";
             break;
         case NE_RETRY:
             code = StatusCode::RedirectionNeeded;
-            str= "Retry Request";
+            str = "Retry Request";
             break;
         default:
-            code= StatusCode::UnknowError;
-            str= "Unknow Error from libneon";
+            code = StatusCode::UnknownError;
+            str = "Unknown Error from libneon";
     }
 
     if(!wwwAuth.empty()) {
@@ -378,7 +378,7 @@ int NeonRequest::negotiateRequest(DavixError** err){
 
 
                 break;
-            case 401: // authentification requested, do retry
+            case 401: // authentication requested, do retry
             case 403:
                 clearAnswerContent();
 
@@ -646,11 +646,11 @@ void NeonRequest::createError(int ne_status, DavixError **err){
              break;
         case NE_TIMEOUT:
             {
-            // check if redirection occured, if redirection occured
+            // check if redirection occurred, if redirection occurred
             // report TimeoutRedirectionError, to allow error recovery
             if(_current != _orig){
                 code = StatusCode::TimeoutRedirectionError;
-                str= "Connection Timeout during redirection on ";
+                str = "Connection Timeout during redirection on ";
                 str+= _current->getString();
                 break;
             }

--- a/src/neon/neonrequest.hpp
+++ b/src/neon/neonrequest.hpp
@@ -137,7 +137,7 @@ private:
     void configureHeaders();
     void cancelSessionReuse();
 
-    // negociate the request : authentification, redirection, name resolution
+    // negociate the request : authentication, redirection, name resolution
     int negotiateRequest(DavixError** err);
 
     // redirection logic

--- a/src/neon/neonsession.cpp
+++ b/src/neon/neonsession.cpp
@@ -78,7 +78,7 @@ void NEONSession::authNeonCliCertMapper(void *userdata, ne_session *sess,
         TRY_DAVIX{
             params->getClientCertFunctionX509()(infos, cert);
             if(cert.hasCert() == false){
-                throw DavixException(davix_scope_x509cred(), StatusCode::AuthentificationError,
+                throw DavixException(davix_scope_x509cred(), StatusCode::AuthenticationError,
                                      "No valid credential given ");
             }
             ne_ssl_set_clicert(req->_sess->session, X509CredentialExtra::extract_ne_ssl_clicert(cert));
@@ -95,7 +95,7 @@ int NEONSession::provide_login_passwd_fn(void *userdata, const char *realm, int 
     int ret =-1;
 
 
-    DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_HTTP, "Try to get auth/password authentification from client");
+    DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_HTTP, "Try to get auth/password authentication from client");
 
      if(attempt > n_max_auth ){
          DavixError::setupError(&(req->_last_error), davix_scope_http_request(), StatusCode::LoginPasswordError,
@@ -225,7 +225,7 @@ void configureSession(NeonHandlePtr &_sess, const Uri & _u, const RequestParams 
         DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_HTTP, "disable login/password authentication");
     }
 
-    // if authentification for cli cert by callback
+    // if authentication for cli cert by callback
     if( params.getClientCertFunctionX509()){
         DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_HTTP, "enable client cert authentication by callback ");
         ne_ssl_provide_clicert(_sess->session, cred_callback, cred_userdata);

--- a/src/params/davixrequestparams.cpp
+++ b/src/params/davixrequestparams.cpp
@@ -353,7 +353,7 @@ const authFunctionClientCertX509 & RequestParams::getClientCertFunctionX509() co
     return x509->_x509_fun;
 }
 
-/// return the current client side callback for authentification with the current user data
+/// return the current client side callback for authentication with the current user data
 std::pair<authCallbackClientCertX509,void*> RequestParams::getClientCertCallbackX509() const{
     X509Data* x509 = X509Data::instance(d_ptr->_x509_data);
     return x509->_pair;
@@ -367,7 +367,7 @@ void RequestParams::setClientLoginPasswordCallback(authCallbackLoginPasswordBasi
     d_ptr->_call_loginpswwd_userdata = userdata;
 }
 
-/// return the current client side callback for authentification with the current user data
+/// return the current client side callback for authentication with the current user data
 std::pair<authCallbackLoginPasswordBasic,void*> RequestParams::getClientLoginPasswordCallback() const{
     return std::pair<authCallbackLoginPasswordBasic,void*>(d_ptr->_call_loginpswwd, d_ptr->_call_loginpswwd_userdata);
 }

--- a/src/request/httprequest.cpp
+++ b/src/request/httprequest.cpp
@@ -368,8 +368,8 @@ void httpcodeToDavixError(int code, const std::string &scope, const std::string 
         case 401:           /* Unauthorized */
         case 402:           /* Payment Required */
         case 407:           /* Proxy Authentication Required */
-            dav_code = StatusCode::AuthentificationError;
-            str_msg = "Authentification Error";
+            dav_code = StatusCode::AuthenticationError;
+            str_msg = "Authentication Error";
             break;
         case 303:           /* See Other */
         case 404:           /* Not Found */
@@ -439,7 +439,7 @@ void httpcodeToDavixError(int code, const std::string &scope, const std::string 
         case 503:           /* Service Unavailable */
         case 505:           /* HTTP Version Not Supported */
         default:
-            dav_code = StatusCode::UnknowError;
+            dav_code = StatusCode::UnknownError;
             std::ostringstream ss;
             ss << "Unexpected server error: " << code;
             str_msg = ss.str().c_str();

--- a/src/status/davixstatusrequest.cpp
+++ b/src/status/davixstatusrequest.cpp
@@ -191,7 +191,7 @@ DavixException::DavixException(const DavixException &orig) throw() : e(orig.e), 
 
 DavixException::DavixException(DavixError **err) :
 std::exception(),
-  e( "Davix::Error", StatusCode::UnknowError, "Error, no valid DavixError triggered"),
+  e( "Davix::Error", StatusCode::UnknownError, "Error, no valid DavixError triggered"),
 d_ptr(NULL){
     if(err != NULL && *err != NULL){
         e.swap(**err);

--- a/src/tools/davix_op.cpp
+++ b/src/tools/davix_op.cpp
@@ -405,7 +405,7 @@ int ListOp::executeOp(){
 
     if(tmp_err){
         Tool::errorPrint(&tmp_err);
-        std::cerr << std::endl << "Error occured during listing  " << _target_url << " Number of entries processed in current directory: " << entry_counter << ". Continuing..."<< std::endl;
+        std::cerr << std::endl << "Error occurred during listing  " << _target_url << " Number of entries processed in current directory: " << entry_counter << ". Continuing..."<< std::endl;
         std::cerr << std::endl << "Last successful entry is " << last_success_entry << std::endl;
     }
 
@@ -507,7 +507,7 @@ int ListppOp::executeOp(){
 
     if(tmp_err){
         Tool::errorPrint(&tmp_err);
-        std::cerr << std::endl << "Error occured during listing  " << dirQueue.front().first << " Number of entries processed in current directory: " << entry_counter << ". Continuing..."<< std::endl;
+        std::cerr << std::endl << "Error occurred during listing  " << dirQueue.front().first << " Number of entries processed in current directory: " << entry_counter << ". Continuing..."<< std::endl;
         std::cerr << std::endl << "Last successful entry is " << last_success_entry << std::endl;
     }
 

--- a/src/tools/davix_tool_get_main.cpp
+++ b/src/tools/davix_tool_get_main.cpp
@@ -146,7 +146,7 @@ static int populateTaskQueue(Context& c, const Tool::OptParams & opts, std::stri
 
     if(tmp_err){
         Tool::errorPrint(&tmp_err);
-        cerr << endl << "Error occured during listing  " << dirQueue.front().first << " Number of entries processed in current directory: " << entry_counter << ". Continuing..."<< endl;
+        cerr << endl << "Error occurred during listing  " << dirQueue.front().first << " Number of entries processed in current directory: " << entry_counter << ". Continuing..."<< endl;
         cerr << endl << "Last successful entry is " << last_success_entry << endl;
     }
 

--- a/src/tools/davix_tool_ls_main.cpp
+++ b/src/tools/davix_tool_ls_main.cpp
@@ -164,7 +164,7 @@ static int populateTaskQueue(Context& c, const Tool::OptParams & opts, std::stri
 
     if(tmp_err){
         Tool::errorPrint(&tmp_err);
-        std::cerr << std::endl << "Error occured during listing  " << dirQueue.front() << " Number of entries processed in current directory: " << entry_counter << ". Continuing..."<< std::endl;
+        std::cerr << std::endl << "Error occurred during listing  " << dirQueue.front() << " Number of entries processed in current directory: " << entry_counter << ". Continuing..."<< std::endl;
         std::cerr << std::endl << "Last successful entry is " << last_success_entry << std::endl;
     }
 

--- a/src/xml/davxmlparser.cpp
+++ b/src/xml/davxmlparser.cpp
@@ -68,9 +68,9 @@ int XMLSAXParser::parseChunk(const char *partial_string, dav_size_t length){
         if(ret > 0){
             ret =-1;
             const char* ne_parser_err = ne_xml_get_error(_ne_parser);
-            throw Davix::DavixException(davix_scope_xml_parser(), StatusCode::WebDavPropertiesParsingError, "XML Parsing Error: " + std::string((ne_parser_err)?ne_parser_err:"Unknow ne error"));
+            throw Davix::DavixException(davix_scope_xml_parser(), StatusCode::WebDavPropertiesParsingError, "XML Parsing Error: " + std::string((ne_parser_err)?ne_parser_err:"Unknown ne error"));
         }
-        throw Davix::DavixException(davix_scope_xml_parser(), StatusCode::WebDavPropertiesParsingError, "Unknow XML parsing error ");
+        throw Davix::DavixException(davix_scope_xml_parser(), StatusCode::WebDavPropertiesParsingError, "Unknown XML parsing error ");
     }
     return ret;
 }

--- a/test/TestcaseHandler.cpp
+++ b/test/TestcaseHandler.cpp
@@ -195,7 +195,7 @@ TestcaseHandler& TestcaseHandler::makeChild() {
 }
 
 //------------------------------------------------------------------------------
-// Ensure no davix error occured
+// Ensure no davix error occurred
 //------------------------------------------------------------------------------
 bool TestcaseHandler::checkDavixError(Davix::DavixError **err) {
   if(err && *err) {

--- a/test/TestcaseHandler.hpp
+++ b/test/TestcaseHandler.hpp
@@ -82,7 +82,7 @@ public:
   bool ok() const;
 
   //----------------------------------------------------------------------------
-  // Ensure no davix error occured
+  // Ensure no davix error occurred
   //----------------------------------------------------------------------------
   bool checkDavixError(Davix::DavixError **err);
 

--- a/test/drunk-server/ConnectionInitiator.cpp
+++ b/test/drunk-server/ConnectionInitiator.cpp
@@ -82,7 +82,7 @@ ConnectionInitiator::ConnectionInitiator(const std::string &hostname, int port) 
     return;
   }
 
-  // clear any transient errors which might have occured while trying to connect
+  // clear any transient errors which might have occurred while trying to connect
   localerrno = 0;
 
   // make socket non-blocking

--- a/test/functional/davix_test_lib.cpp
+++ b/test/functional/davix_test_lib.cpp
@@ -24,7 +24,7 @@ int mycred_auth_callback_x509(void* userdata, const SessionInfo & info, X509Cred
     int ret = cred->loadFromFileP12( path, "", &tmp_err);
 
     if(ret != 0){
-        fprintf(stderr, " FATAL authentification Error : %s", tmp_err->getErrMsg().c_str());
+        fprintf(stderr, " FATAL authentication Error : %s", tmp_err->getErrMsg().c_str());
         DavixError::propagateError(err, tmp_err);
     }
     return ret;

--- a/test/functional/optionparser.h
+++ b/test/functional/optionparser.h
@@ -1361,7 +1361,7 @@ struct Parser::Action
    * options if they have a Descriptor whose Descriptor::check_arg does not return
    * @ref ARG_ILLEGAL.
    *
-   * Returns @c false iff a fatal error has occured and the parse should be aborted.
+   * Returns @c false iff a fatal error has occurred and the parse should be aborted.
    */
   virtual bool perform(Option&)
   {

--- a/test/functional/test_stat_session.cpp
+++ b/test/functional/test_stat_session.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv){
 
 
 
-    std::cout << "authentification callback has been called " << n_call << std::endl;
+    std::cout << "authentication callback has been called " << n_call << std::endl;
 
     return 0;
 }

--- a/test/unit/datetime.cpp
+++ b/test/unit/datetime.cpp
@@ -11,7 +11,7 @@ TEST(DateTimeTest, testConvert){
     res= parse_iso8601date(buff);
     ASSERT_EQ(t,res);
 
-    res = parse_iso8601date("unknow invalid time");
+    res = parse_iso8601date("unknown invalid time");
     ASSERT_EQ(-1, res);
 }
 


### PR DESCRIPTION
* authentification → authentication
* converstion → conversion
* occured → occurred
* reponse → response
* unknow → unknown