### PR TITLE
Rework authorization headers for CS3

### DIFF
--- a/src/backend/BackendRequest.cpp
+++ b/src/backend/BackendRequest.cpp
@@ -135,56 +135,56 @@ void BackendRequest::configureSwiftParams() {
     _current.reset(new Uri(signed_url));
 }
 
-  //------------------------------------------------------------------------------
-  // Configure request for Reva.
-  //------------------------------------------------------------------------------
-  void BackendRequest::configureRevaParams() 
-  {
-    std::string uri = getOriginalUri()->getString();
+//------------------------------------------------------------------------------
+// Configure request for Reva.
+//------------------------------------------------------------------------------
+void BackendRequest::configureRevaParams()
+{
+  std::string uri = getOriginalUri()->getString();
 
-    if (_request_type != "COPY") {
-      std::string token = _params.getRevaToken(uri);
-      if (token != ""){
+  if (_request_type != "COPY") {
+    std::string token = _params.getRevaToken(uri);
+    if (token != ""){
       _headers_field.emplace_back("X-Access-Token", token);
-      }
-    }
-    else {
-      reva::CredentialMap cmap;
-      _params.getRevaCredentialMap(cmap);
-
-      //In pull mode : Dst = Active Endpoint and Src = Passive Endpoint
-      //In push mode : Dst = Passive Endpoint and Src = Active Endpoint
-      std::string active_token, passive_token;
-
-      //In pull mode original uri = destination uri
-      if(_params.getCopyMode() == Davix::CopyMode::Pull){
-          for (reva::CredentialMap::iterator itr = cmap.begin(); itr != cmap.end(); ++itr) {
-            if(itr->second.token_write_access){
-              active_token = itr->second.token;
-            }
-            else{
-              passive_token = itr->second.token;
-            }
-          }
-        }
-
-      //In push mode original uri = src uri
-      else if(_params.getCopyMode() == Davix::CopyMode::Push){
-          for (reva::CredentialMap::iterator itr = cmap.begin(); itr != cmap.end(); ++itr) {
-            if(itr->second.token_write_access){
-              passive_token = itr->second.token;
-            }
-            else{
-              active_token = itr->second.token;
-            }
-          }
-        }
-
-      _headers_field.emplace_back("X-Access-Token", active_token);
-      _headers_field.emplace_back("TransferHeaderX-Access-Token", passive_token);
-
     }
   }
+  else {
+    reva::CredentialMap cmap;
+    _params.getRevaCredentialMap(cmap);
+
+    //In pull mode : Dst = Active Endpoint and Src = Passive Endpoint
+    //In push mode : Dst = Passive Endpoint and Src = Active Endpoint
+    std::string active_token, passive_token;
+
+    //In pull mode original uri = destination uri
+    if(_params.getCopyMode() == Davix::CopyMode::Pull){
+      for (reva::CredentialMap::iterator itr = cmap.begin(); itr != cmap.end(); ++itr) {
+        if(itr->second.token_write_access){
+          active_token = itr->second.token;
+        }
+        else{
+          passive_token = itr->second.token;
+        }
+      }
+    }
+
+    //In push mode original uri = src uri
+    else if(_params.getCopyMode() == Davix::CopyMode::Push){
+      for (reva::CredentialMap::iterator itr = cmap.begin(); itr != cmap.end(); ++itr) {
+        if(itr->second.token_write_access){
+          passive_token = itr->second.token;
+        }
+        else{
+          active_token = itr->second.token;
+        }
+      }
+    }
+
+    _headers_field.emplace_back("X-Access-Token", active_token);
+    _headers_field.emplace_back("TransferHeaderX-Access-Token", passive_token);
+
+  }
+}
 
 
 //------------------------------------------------------------------------------

--- a/src/backend/BackendRequest.cpp
+++ b/src/backend/BackendRequest.cpp
@@ -145,7 +145,7 @@ void BackendRequest::configureRevaParams()
   if (_request_type != "COPY") {
     std::string token = _params.getRevaToken(uri);
     if (token != ""){
-      _headers_field.emplace_back("X-Access-Token", token);
+      _headers_field.emplace_back("Authorization", "Bearer " + token);
     }
   }
   else {
@@ -180,8 +180,8 @@ void BackendRequest::configureRevaParams()
       }
     }
 
-    _headers_field.emplace_back("X-Access-Token", active_token);
-    _headers_field.emplace_back("TransferHeaderX-Access-Token", passive_token);
+    _headers_field.emplace_back("Authorization", "Bearer " + active_token);
+    _headers_field.emplace_back("TransferHeaderAuthorization", passive_token);
 
   }
 }

--- a/src/utils/davix_cs3_utils.cpp
+++ b/src/utils/davix_cs3_utils.cpp
@@ -62,7 +62,7 @@ void Credentials::getCredentialMap(CredentialMap & cmap) const {
      }
 }
 
-void Credentials::addCredentials(std::string uri, std::string token, bool token_write_access){
+void Credentials::addCredentials(std::string uri, std::string token, bool token_write_access) {
     
     if(credMap->find(uri) == credMap->end()){
         Credential cred {token, token_write_access};
@@ -71,45 +71,18 @@ void Credentials::addCredentials(std::string uri, std::string token, bool token_
 }
 
 
-// Helper function
-// To convert char* to string safely
-std::string getEnvStr(std::string var){
-  char* val = getenv(var.c_str());
-  return val == NULL ?   std::string() : std::string(val);
-}
-
 //
 // Credential Provider
 //
 
-void CredentialProvider::updateCredentials(Credentials &creds, std::string uri, bool token_write_access){
-    
+void CredentialProvider::updateCredentials(Credentials &creds, std::string uri, bool token_write_access) {
     //Assuming urls with +3rd prefix have been deprecated
-
-    std::string src_url, dst_url, token;
-
-    src_url = getEnvStr("SRC_URL");
-    dst_url = getEnvStr("DST_URL");
-
-    // Src and Dst env var need to be set as env var for the time being
-    // This will be removed in the future 
-  
-    if (src_url == "" || dst_url == ""){
-      throw DavixException(std::string("davix::reva"), StatusCode::EnvVarNotSet, "Source or Destination variable is not set");
+    char* token = getenv("REVA_TOKEN");
+    if(token == NULL) {
+        throw DavixException(std::string("davix::reva"), StatusCode::EnvVarNotSet, "REVA_TOKEN variable is not set");
     }
 
-    // If any required token is not set we get an empty string 
-    // When this happens copy fails with Authentication error
-
-    if(uri.compare(dst_url) <= 0 ){
-      token = getEnvStr("REVA_DST_TOKEN");
-    }
-    else if (uri.compare(src_url) <= 0 ){
-      token = getEnvStr("REVA_SRC_TOKEN");
-    }
-
-   creds.addCredentials(uri, token, token_write_access);
-    
+    creds.addCredentials(uri, std::string(token), token_write_access);
 }
 
 } //reva


### PR DESCRIPTION
This PR fixes the headers to use the standard `Authorization: Bearer` tokens against Reva and simplifies the whole authentication by requiring a single token to the user.
