### PR TITLE
Do not #include inside a namespace

### DIFF
--- a/src/libs/alibxx/str/format.hpp
+++ b/src/libs/alibxx/str/format.hpp
@@ -22,9 +22,6 @@
 #define A_LIB_NAMESPACE Davix
 #endif
 
-namespace A_LIB_NAMESPACE {
-
-
 #if _SECURE_SCL
 # include <iterator>
 #endif
@@ -96,6 +93,8 @@ namespace A_LIB_NAMESPACE {
 #define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
   TypeName(const TypeName&); \
   void operator=(const TypeName&)
+
+namespace A_LIB_NAMESPACE {
 
 namespace fmt {
 


### PR DESCRIPTION
This PR fixes errors like:

error: 'move' has not been declared in 'Davix::std'
error: 'size_t' in namespace 'Davix::std' does not name a type
error: 'Davix::std::size_t' has not been declared
error: 'basic_string' in namespace 'Davix::std' does not name a template type
error: class 'Davix::fmt::BasicStringRef<Char>' does not have any field named 'size_'
error: 'char_traits' is not a member of 'Davix::std'

These errors occurred with gcc 12 on Fedora 36 (rawhide).