### PR TITLE
Remove std::move from return statement

### DIFF
--- a/test/drunk-server/DrunkServer.cpp
+++ b/test/drunk-server/DrunkServer.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<DrunkServer::Connection> DrunkServer::accept(int timeoutSeconds)
       int clientFd = _overflowFds.front();
       std::unique_ptr<Connection> conn = std::unique_ptr<Connection>(new Connection(clientFd));
       _overflowFds.pop_front();
-      return std::move(conn);
+      return conn;
     }
 
     _cv.wait_until(lock, deadline);


### PR DESCRIPTION
~~~
.../test/drunk-server/DrunkServer.cpp:116:23: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
  116 |       return std::move(conn);
      |              ~~~~~~~~~^~~~~~
.../test/drunk-server/DrunkServer.cpp:116:23: note: remove 'std::move' call
~~~
