### PR TITLE
Remove unused variables

### DIFF
--- a/src/curl/StandaloneCurlRequest.cpp
+++ b/src/curl/StandaloneCurlRequest.cpp
@@ -305,7 +305,6 @@ Status StandaloneCurlRequest::startRequest() {
   // Set request verb, target URL
   //----------------------------------------------------------------------------
   CURL* handle = _session->getHandle()->handle;
-  CURLM* mhandle = _session->getHandle()->mhandle;
 
   Uri uriCopy(_uri);
   uriCopy.httpizeProtocol();

--- a/src/modules/copy/delegation/GRSTx509MakeProxyCert.cpp
+++ b/src/modules/copy/delegation/GRSTx509MakeProxyCert.cpp
@@ -113,7 +113,7 @@ int GRSTx509MakeProxyCert(char **proxychain, FILE *debugfp,
                   X509v3_KU_KEY_AGREEMENT,
                   0 };
   int i, ncerts, any_rfc_proxies = 0;
-  long serial = 1234, ptrlen;
+  long ptrlen;
   EVP_PKEY *pkey, *CApkey;
   const EVP_MD *digest;
   X509 **certs = NULL;


### PR DESCRIPTION
~~~
.../src/curl/StandaloneCurlRequest.cpp:308:10: warning: unused variable 'mhandle' [-Wunused-variable]
  308 |   CURLM* mhandle = _session->getHandle()->mhandle;
      |          ^~~~~~~

.../src/modules/copy/delegation/GRSTx509MakeProxyCert.cpp:116:8: warning: unused variable 'serial' [-Wunused-variable]
  116 |   long serial = 1234, ptrlen;
      |        ^~~~~~
~~~
