### PR TITLE
Re-enable test to be run with ctest (or make test / ninja test)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ endif()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/deps/libneon/src/ ${UUID_INCLUDE_DIRS})
 include_directories(${CMAKE_SOURCE_DIR}/include/davix)
 
+include(CTest)
+
 add_subdirectory (src)
 add_subdirectory (doc)
 

--- a/test/slow-unit/CMakeLists.txt
+++ b/test/slow-unit/CMakeLists.txt
@@ -30,3 +30,5 @@ target_link_libraries(davix-slow-unit-tests
   ${CMAKE_THREAD_LIBS_INIT}
   ${LIBSSL_PKG_LIBRARIES}
 )
+
+add_test(slow-unit-tests davix-slow-unit-tests)


### PR DESCRIPTION
This includes again the `CTest` module so that tests can be run with `make test` or just `ctest`.