### PR TITLE
Do not hardcode error numbers

### DIFF
--- a/test/unit/content-provider.cpp
+++ b/test/unit/content-provider.cpp
@@ -90,14 +90,14 @@ TEST(ContentProvider, Fd) {
   // .. but the fd closes..
   ASSERT_EQ(close(fd), 0);
 
-  ASSERT_EQ(provider.pullBytes(buffer, 3), -9);
-  ASSERT_EQ(provider.getErrc(), 9);
+  ASSERT_EQ(provider.pullBytes(buffer, 3), -EBADF);
+  ASSERT_EQ(provider.getErrc(), EBADF);
   ASSERT_EQ(provider.getError(), "Bad file descriptor");
 
   for(size_t i = 0; i < 10; i++) {
     ASSERT_FALSE(provider.ok());
     ASSERT_FALSE(provider.rewind());
-    ASSERT_EQ(provider.pullBytes(buffer, 3), -9);
+    ASSERT_EQ(provider.pullBytes(buffer, 3), -EBADF);
   }
 
   // remove test file


### PR DESCRIPTION
Test fails when EBADF != 9:

[----------] 7 tests from ContentProvider
[ RUN      ] ContentProvider.Fd
./test/unit/content-provider.cpp:93: Failure
Expected equality of these values:
  provider.pullBytes(buffer, 3)
    Which is: -1073741833
  -9
[  FAILED  ] ContentProvider.Fd (0 ms)

From /usr/include/i386-gnu/bits/errno.h:
  EBADF                          = 0x40000009,  /* Bad file descriptor */