### PR TITLE
Add git mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,28 @@
+Adrien Devresse <adrien.devresse@cern.ch>
+Adrien Devresse <adrien.devresse@cern.ch> <Adev88@gmail.com>
+Adrien Devresse <adrien.devresse@cern.ch> <Adrien.Devresse@cern.ch>
+Adrien Devresse <adrien.devresse@cern.ch> <adevress@20f574310525.(none)>
+Adrien Devresse <adrien.devresse@cern.ch> <adevress@4525493e-7705-40b1-a816-d608a930855b>
+Adrien Devresse <adrien.devresse@cern.ch> <adevress@ADEV-WIN.cern.ch>
+Adrien Devresse <adrien.devresse@cern.ch> <adevress@adev-sl6-2.cern.ch>
+Adrien Devresse <adrien.devresse@cern.ch> <adevress@adev-sl6x86-1.cern.ch>
+Adrien Devresse <adrien.devresse@cern.ch> <adevress@adevvm-sl6-1.cern.ch>
+Adrien Devresse <adrien.devresse@cern.ch> <adevress@cern.ch>
+Adrien Devresse <adrien.devresse@cern.ch> <adrien.devress@cern.ch>
+Adrien Devresse <adrien.devresse@cern.ch> <adrien.devresse@epfl.ch>
+Adrien Devresse <adrien.devresse@cern.ch> <didi-laptop>
+Adrien Devresse <adrien.devresse@cern.ch> <didi@pb-d-128-141-56-111.cern.ch>
+Alejandro Alvarez Ayllon <alejandro.alvarez.ayllon@cern.ch> <a.alvarezayllon@gmail.com>
+Alejandro Alvarez Ayllon <alejandro.alvarez.ayllon@cern.ch> <aalvarez@4525493e-7705-40b1-a816-d608a930855b>
+Andrea Manzi <andrea.manzi@cern.ch> <amanzi@cern.ch>
+Andrea Manzi <andrea.manzi@cern.ch> <andrea.manzi@gmail.com>
+Edward James Dambik <edambik@cern.ch>
+Fabrizio Furano <furano@cern.ch>
+Fabrizio Furano <furano@cern.ch> <furano@4525493e-7705-40b1-a816-d608a930855b>
+Georgios Bitzes <georgios.bitzes@cern.ch> <gbitzes@users.noreply.github.com>
+Georgios Bitzes <georgios.bitzes@cern.ch> <geobijes@gmail.com>
+Kwong Tat Cheung <kwong.tat.cheung@cern.ch>
+Mattias Ellert <mattias.ellert@physics.uu.se> <mattias.ellert@fysast.uu.se>
+Rahul Chauhan <omrahulchauhan@gmail.com>
+Shiting Long <s.long@fz-juelich.de> <ashleylst96@gmail.com>
+Unknown <davix@macroot3.cern.ch>


### PR DESCRIPTION
This file is used to map author and committer names and email addresses to canonical real names and email addresses. This is useful when using git blame, git shortlog, etc. For more information, see gitmailmap(5).