### PR TITLE
Implement chunked streaming for writes.

### DIFF
--- a/src/core/ContentProvider.cpp
+++ b/src/core/ContentProvider.cpp
@@ -188,6 +188,8 @@ ssize_t FdContentProvider::pullBytes(char* target, size_t requestedBytes) {
 
   while(true) {
     ssize_t retval = ::read(_fd, target, requestedBytes);
+    std::cerr<<"Read: FD="<<_fd <<" bytes="<<requestedBytes<<" rc="<<retval<<
+    std::endl;
 
     if(retval >= 0) {
       // No errors
@@ -202,6 +204,7 @@ ssize_t FdContentProvider::pullBytes(char* target, size_t requestedBytes) {
       // Error
       _errc = errno;
       _errMsg = strerror(_errc);
+      if (_errc == EFAULT) abort(); 
       return - _errc;
     }
   }

--- a/src/core/ContentProvider.cpp
+++ b/src/core/ContentProvider.cpp
@@ -188,8 +188,6 @@ ssize_t FdContentProvider::pullBytes(char* target, size_t requestedBytes) {
 
   while(true) {
     ssize_t retval = ::read(_fd, target, requestedBytes);
-    std::cerr<<"Read: FD="<<_fd <<" bytes="<<requestedBytes<<" rc="<<retval<<
-    std::endl;
 
     if(retval >= 0) {
       // No errors

--- a/src/file/davposix.cpp
+++ b/src/file/davposix.cpp
@@ -688,9 +688,11 @@ ssize_t DavPosix::write(DAVIX_FD* fd, const void* buf, size_t count, Davix::Davi
 
 // The envar XRDCL_PROXY indicates that the caller is actually a proxy server.
 // For proxy servers we use multipart upload (a.k.a. chunked streaming) to avoid
-// consuming excessive intermediate disk space for data buffering.
+// consuming excessive intermediate disk space for data buffering. Note that
+// multipart uploads are enabled when isProxy is true because XRDCL_PROXY is
+// defined in the environment.
 //
-    static bool isProxy = getenv("XRDCL_PROXY") != 0;
+    static bool isProxy = getenv("XRDCL_PROXY") != 0; // Enable multipart upload?
 
     DAVIX_SCOPE_TRACE(DAVIX_LOG_POSIX, fun_write);
     ssize_t ret =-1;

--- a/src/fileops/S3IO.cpp
+++ b/src/fileops/S3IO.cpp
@@ -36,12 +36,14 @@ static bool is_s3_operation(IOChainContext & context){
   return false;
 }
 
+extern bool ForceMP;
+
 static bool should_use_s3_multipart(IOChainContext & context, dav_size_t size) {
   bool is_s3 = is_s3_operation(context);
 
   if(!is_s3) return false;
 
-  if(context._uri.fragmentParamExists("forceMultiPart")) {
+  if(ForceMP || context._uri.fragmentParamExists("forceMultiPart")) {
 
     return true;
   }
@@ -184,6 +186,13 @@ static dav_size_t fillBufferWithProviderData(std::vector<char> &buffer, const da
 
     DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_CHAIN, "Retrieved {} bytes from data provider", written);
     return written;
+}
+
+// write from a buffer
+void S3IO::writeFromBuffer(IOChainContext& iocontext, const char* buff,
+                           dav_size_t size, const std::string& uploadId,
+                           std::vector<std::string>& etags, int partNumber) {
+  etags.emplace_back(writeChunk(iocontext, buff, size, uploadId, partNumber));
 }
 
 // write from content provider

--- a/src/fileops/S3IO.hpp
+++ b/src/fileops/S3IO.hpp
@@ -39,12 +39,25 @@ public:
   // write from content provider
   virtual dav_ssize_t writeFromProvider(IOChainContext & iocontext, ContentProvider &provider);
 
+  // Returns uploadId
+  virtual std::string initiateMultipart(IOChainContext & iocontext);
+
+  // Given the upload id and part#, write the given buffer and add the
+  // object id to the etags vector.
+  virtual void writeFromBuffer(IOChainContext&  iocontext, const char* buff,
+                               dav_size_t size, const std::string& uploadId,
+                               std::vector<std::string>& etags, int partNumber);
+
+  // Given upload id and last chunk, commit chunks
+  virtual void commitChunks(IOChainContext& iocontext,
+                            const std::string& uploadId,
+                            const std::vector<std::string>& etags);
+
   void performUgrS3MultiPart(IOChainContext & iocontext, const std::string &posturl, const std::string &pluginId, ContentProvider &provider, DavixError **err);
 
 private:
 
   // Returns uploadId
-  std::string initiateMultipart(IOChainContext & iocontext);
   std::string initiateMultipart(IOChainContext & iocontext, const Uri &url);
 
   DynafedUris retrieveDynafedUris(IOChainContext & iocontext, const std::string &uploadId, const std::string &pluginId, size_t nchunks);
@@ -56,7 +69,6 @@ private:
 
 
   // Given upload id and last chunk, commit chunks
-  void commitChunks(IOChainContext & iocontext,  const std::string &uploadId, const std::vector<std::string> &etags);
   void commitChunks(IOChainContext & iocontext,  const Uri &uri, const std::vector<std::string> &etags);
 };
 

--- a/src/fileops/SwiftIO.cpp
+++ b/src/fileops/SwiftIO.cpp
@@ -35,12 +35,14 @@ static bool is_swift_operation(IOChainContext & context){
     return false;
 }
 
+extern bool ForceMP;
+
 static bool should_use_swift_multipart(IOChainContext & context, dav_size_t size) {
     bool is_swift = is_swift_operation(context);
 
     if (!is_swift) return false;
 
-    if(context._uri.fragmentParamExists("forceMultiPart")) {
+    if(ForceMP || context._uri.fragmentParamExists("forceMultiPart")) {
 
         return true;
     }

--- a/src/fileops/httpiochain.hpp
+++ b/src/fileops/httpiochain.hpp
@@ -138,7 +138,7 @@ public:
     virtual dav_ssize_t readToFd(IOChainContext & iocontext, int fd, dav_size_t size);
 
     virtual dav_ssize_t preadVec(IOChainContext & iocontext, const DavIOVecInput * input_vec,
-                              DavIOVecOuput * output_vec,
+                             DavIOVecOuput * output_vec,
                               const dav_size_t count_vec);
 
     // reset file position and status
@@ -159,6 +159,25 @@ public:
 
     // write provided contents
     virtual dav_ssize_t writeFromProvider(IOChainContext & iocontext, ContentProvider &provider);
+
+    // S3-type operations needed for streaming writes especially when the size
+    // is unknown (common case).
+
+    // Returns uploadId
+    virtual std::string initiateMultipart(IOChainContext& iocontext)
+                                          {return std::string("");}
+
+    // Given the upload id and part#, write the given buffer and add the
+    // object id to the etags vector.
+    virtual void writeFromBuffer(IOChainContext&  iocontext, const char* buff,
+                                 dav_size_t size, const std::string& uploadId,
+                                 std::vector<std::string>& etags,
+                                 int partNumber) {}
+
+    // Given upload id and list of object tags, commit chunks
+    virtual void commitChunks(IOChainContext& iocontext,
+                              const std::string &uploadId,
+                              const std::vector<std::string> &etags) {};
 
 protected:
     std::unique_ptr<HttpIOChain> _next;

--- a/src/utils/CompatibilityHacks.cpp
+++ b/src/utils/CompatibilityHacks.cpp
@@ -108,7 +108,8 @@ bool CompatibilityHacks::dynafedAssistedS3Upload(const BackendRequest& originati
 
   // Don't engage if size to upload is less than the specified threshold.
   // Override with 'forceMultiPart' fragment param.
-  if(provider.getSize() < s3SizeThreshold && !uri.fragmentParamExists("forceMultiPart")) {
+  if((uint64_t)provider.getSize() < s3SizeThreshold &&
+     !uri.fragmentParamExists("forceMultiPart")) {
     return false;
   }
 

--- a/src/utils/davix_logger.cpp
+++ b/src/utils/davix_logger.cpp
@@ -28,11 +28,13 @@
 
 #ifdef HAVE_ATOMIC
 #include <atomic>
-static std::atomic<int> internal_log_level(0);
+//static std::atomic<int> internal_log_level(0);
+static std::atomic<int> internal_log_level(DAVIX_LOG_TRACE);
 static std::atomic<int> internal_log_scope(DAVIX_LOG_SCOPE_ALL);
 #else
 #warning "Setting / getting davix loglevel is not thread-safe!"
-int internal_log_level = 0;
+//int internal_log_level = 0;
+int internal_log_level = DAVIX_LOG_TRACE;
 int internal_log_scope = DAVIX_LOG_SCOPE_ALL;
 #endif
 

--- a/test/functional/davix-tester.cpp
+++ b/test/functional/davix-tester.cpp
@@ -144,7 +144,8 @@ void authentication(const std::vector<option::Option> &opts, const Auth::Type &a
         if(opts[Opt::S3ALTERNATE]) params.setAwsAlternate(true);
     }
     else if(auth == Auth::PROXY) {
-        configure_grid_env("proxy", params);
+        char pxy[] = "proxy";
+        configure_grid_env(pxy, params);
     }
     else if(auth == Auth::AZURE) {
         ASSERT(opts[Opt::AZUREKEY] != NULL, "--azurekey is required when using Azure");
@@ -621,7 +622,7 @@ void detectwebdav(TestcaseHandler &handler, const RequestParams &params, const U
 
 void assert_args(const std::vector<std::string> &cmd, int nargs) {
     ASSERT(cmd.size() != 0, "assert_args called with empty command!");
-    ASSERT(cmd.size() == nargs+1, "Wrong number of arguments to " << cmd[0] << ": " << cmd.size()-1 << ", expected: " << nargs);
+    ASSERT((int)cmd.size() == nargs+1, "Wrong number of arguments to " << cmd[0] << ": " << cmd.size()-1 << ", expected: " << nargs);
 }
 
 bool run(int argc, char** argv) {


### PR DESCRIPTION
This update implements chunked streaming for files of unknown size and is only used in the Posix write() case. It avoids the need to create a local file that is then transferred to the destination upon close.

The default chunk size is 32MB but can be changed by setting the envar DAVIX_PARTSIZE to he desired value in megabytes (e.g. a value of 50 is converted to 50 megabytes). Invalid values are ignored. The valid range if from 10 to 500, inclusive. Note that once set it cannot be changed until the library is reloaded.