### PR TITLE
Support 64 bit off_t on 32 bit systems (LFS)

### DIFF
--- a/deps/libneon/config.cmake.in
+++ b/deps/libneon/config.cmake.in
@@ -145,8 +145,10 @@
 
 #if( SIZEOF_INT == SIZEOF_OFF_T )
 #   define NE_FMT_OFF_T "d"
-#else
+#elif( SIZEOF_LONG == SIZEOF_OFF_T )
 #   define NE_FMT_OFF_T "ld"
+#else
+#   define NE_FMT_OFF_T "lld"
 #endif
 
 


### PR DESCRIPTION
Debian recently enabled 64 bit time_t on most of their 32 bit architectures by default. Since it is not possible to have a 64 bit time_t and a 32 bit off_t, this means that also large file support (64 bit off_t) was enabled by default. This PR addresses some format warnings due to this change.