### PR TITLE
Implement multipart streaming for DavPosix::write()

### DIFF
--- a/src/file/davposix.cpp
+++ b/src/file/davposix.cpp
@@ -63,8 +63,6 @@ size_t getPartSize() {static const int dfltPSIZE = 32*1024*1024;
 
 size_t PartSize = getPartSize();
 
-bool   ForceMP  = getenv("DAVIX_FORCEMP") != 0;
-
 } // namespace Davix
 
 // static const std::string simple_listing("<propfind xmlns=\"DAV:\"><prop><resourcetype><collection/></resourcetype></prop></propfind>");

--- a/src/fileops/S3IO.cpp
+++ b/src/fileops/S3IO.cpp
@@ -36,14 +36,12 @@ static bool is_s3_operation(IOChainContext & context){
   return false;
 }
 
-extern bool ForceMP;
-
 static bool should_use_s3_multipart(IOChainContext & context, dav_size_t size) {
   bool is_s3 = is_s3_operation(context);
 
   if(!is_s3) return false;
 
-  if(ForceMP || context._uri.fragmentParamExists("forceMultiPart")) {
+  if(context._uri.fragmentParamExists("forceMultiPart")) {
 
     return true;
   }

--- a/src/fileops/S3IO.cpp
+++ b/src/fileops/S3IO.cpp
@@ -127,11 +127,12 @@ std::string S3IO::writeChunk(IOChainContext & iocontext, const char* buff, dav_s
   return etag;
 }
 
-void S3IO::commitChunks(IOChainContext & iocontext,  const std::string &uploadId, const std::vector<std::string> &etags) {
+bool S3IO::commitChunks(IOChainContext & iocontext,  const std::string &uploadId, const std::vector<std::string> &etags) {
   Uri url(iocontext._uri);
   url.addQueryParam("uploadId", uploadId);
 
-  return commitChunks(iocontext, url, etags);
+  commitChunks(iocontext, url, etags);
+  return true;
 }
 
 void S3IO::commitChunks(IOChainContext & iocontext,  const Uri &url, const std::vector<std::string> &etags) {
@@ -189,10 +190,11 @@ static dav_size_t fillBufferWithProviderData(std::vector<char> &buffer, const da
 }
 
 // write from a buffer
-void S3IO::writeFromBuffer(IOChainContext& iocontext, const char* buff,
+bool S3IO::writeFromBuffer(IOChainContext& iocontext, const char* buff,
                            dav_size_t size, const std::string& uploadId,
                            std::vector<std::string>& etags, int partNumber) {
   etags.emplace_back(writeChunk(iocontext, buff, size, uploadId, partNumber));
+  return true;
 }
 
 // write from content provider

--- a/src/fileops/S3IO.hpp
+++ b/src/fileops/S3IO.hpp
@@ -39,12 +39,25 @@ public:
   // write from content provider
   virtual dav_ssize_t writeFromProvider(IOChainContext & iocontext, ContentProvider &provider);
 
+  // Returns uploadId
+  virtual std::string initiateMultipart(IOChainContext & iocontext);
+
+  // Given the upload id and part#, write the given buffer and add the
+  // object id to the etags vector.
+  virtual void writeFromBuffer(IOChainContext&  iocontext, const char* buff,
+                               dav_size_t size, const std::string& uploadId,
+                               std::vector<std::string>& etags, int partNumber);
+
+  // Given upload id and last chunk, commit chunks
+  virtual void commitChunks(IOChainContext& iocontext,
+                            const std::string& uploadId,
+                            const std::vector<std::string>& etags);
+
   void performUgrS3MultiPart(IOChainContext & iocontext, const std::string &posturl, const std::string &pluginId, ContentProvider &provider, DavixError **err);
 
 private:
 
   // Returns uploadId
-  std::string initiateMultipart(IOChainContext & iocontext);
   std::string initiateMultipart(IOChainContext & iocontext, const Uri &url);
 
   DynafedUris retrieveDynafedUris(IOChainContext & iocontext, const std::string &uploadId, const std::string &pluginId, size_t nchunks);
@@ -56,7 +69,6 @@ private:
 
 
   // Given upload id and last chunk, commit chunks
-  void commitChunks(IOChainContext & iocontext,  const std::string &uploadId, const std::vector<std::string> &etags);
   void commitChunks(IOChainContext & iocontext,  const Uri &uri, const std::vector<std::string> &etags);
 };
 

--- a/src/fileops/S3IO.hpp
+++ b/src/fileops/S3IO.hpp
@@ -40,18 +40,19 @@ public:
   virtual dav_ssize_t writeFromProvider(IOChainContext & iocontext, ContentProvider &provider);
 
   // Returns uploadId
-  virtual std::string initiateMultipart(IOChainContext & iocontext);
+  virtual std::string initiateMultipart(IOChainContext & iocontext) override;
 
   // Given the upload id and part#, write the given buffer and add the
   // object id to the etags vector.
-  virtual void writeFromBuffer(IOChainContext&  iocontext, const char* buff,
+  virtual bool writeFromBuffer(IOChainContext&  iocontext, const char* buff,
                                dav_size_t size, const std::string& uploadId,
-                               std::vector<std::string>& etags, int partNumber);
+                               std::vector<std::string>& etags, int partNumber)
+                               override;
 
   // Given upload id and last chunk, commit chunks
-  virtual void commitChunks(IOChainContext& iocontext,
+  virtual bool commitChunks(IOChainContext& iocontext,
                             const std::string& uploadId,
-                            const std::vector<std::string>& etags);
+                            const std::vector<std::string>& etags) override;
 
   void performUgrS3MultiPart(IOChainContext & iocontext, const std::string &posturl, const std::string &pluginId, ContentProvider &provider, DavixError **err);
 

--- a/src/fileops/SwiftIO.cpp
+++ b/src/fileops/SwiftIO.cpp
@@ -35,12 +35,14 @@ static bool is_swift_operation(IOChainContext & context){
     return false;
 }
 
+extern bool ForceMP;
+
 static bool should_use_swift_multipart(IOChainContext & context, dav_size_t size) {
     bool is_swift = is_swift_operation(context);
 
     if (!is_swift) return false;
 
-    if(context._uri.fragmentParamExists("forceMultiPart")) {
+    if(ForceMP || context._uri.fragmentParamExists("forceMultiPart")) {
 
         return true;
     }

--- a/src/fileops/SwiftIO.cpp
+++ b/src/fileops/SwiftIO.cpp
@@ -35,14 +35,12 @@ static bool is_swift_operation(IOChainContext & context){
     return false;
 }
 
-extern bool ForceMP;
-
 static bool should_use_swift_multipart(IOChainContext & context, dav_size_t size) {
     bool is_swift = is_swift_operation(context);
 
     if (!is_swift) return false;
 
-    if(ForceMP || context._uri.fragmentParamExists("forceMultiPart")) {
+    if(context._uri.fragmentParamExists("forceMultiPart")) {
 
         return true;
     }

--- a/src/fileops/httpiochain.cpp
+++ b/src/fileops/httpiochain.cpp
@@ -131,9 +131,26 @@ dav_ssize_t HttpIOChain::write(IOChainContext & iocontext, const void *buf, dav_
     CHAIN_FORWARD(write(iocontext, buf, count));
 }
 
+void HttpIOChain::writeFromBuffer(IOChainContext&  iocontext, const char* buff,
+                                  dav_size_t size, const std::string& uploadId,
+                                  std::vector<std::string>& etags,
+                                  int partNumber) {
+    CHAIN_FORWARD_VOID(writeFromBuffer(iocontext, buff, size, uploadId,
+                       etags, partNumber));
+}
+
 dav_ssize_t HttpIOChain::writeFromProvider(IOChainContext & iocontext, ContentProvider &provider) {
     CHAIN_FORWARD(writeFromProvider(iocontext, provider));
 }
 
+std::string HttpIOChain::initiateMultipart(IOChainContext& iocontext) {
+     CHAIN_FORWARD(initiateMultipart(iocontext));
+}
+
+void HttpIOChain::commitChunks(IOChainContext& iocontext,
+                               const std::string &uploadId,
+                               const std::vector<std::string> &etags) {
+     CHAIN_FORWARD_VOID(commitChunks(iocontext, uploadId, etags));
+}
 
 } // Davix

--- a/src/fileops/httpiochain.cpp
+++ b/src/fileops/httpiochain.cpp
@@ -131,12 +131,11 @@ dav_ssize_t HttpIOChain::write(IOChainContext & iocontext, const void *buf, dav_
     CHAIN_FORWARD(write(iocontext, buf, count));
 }
 
-void HttpIOChain::writeFromBuffer(IOChainContext&  iocontext, const char* buff,
+bool HttpIOChain::writeFromBuffer(IOChainContext&  iocontext, const char* buff,
                                   dav_size_t size, const std::string& uploadId,
                                   std::vector<std::string>& etags,
                                   int partNumber) {
-    CHAIN_FORWARD_VOID(writeFromBuffer(iocontext, buff, size, uploadId,
-                       etags, partNumber));
+    CHAIN_FORWARD(writeFromBuffer(iocontext,buff,size,uploadId,etags,partNumber));
 }
 
 dav_ssize_t HttpIOChain::writeFromProvider(IOChainContext & iocontext, ContentProvider &provider) {
@@ -147,10 +146,10 @@ std::string HttpIOChain::initiateMultipart(IOChainContext& iocontext) {
      CHAIN_FORWARD(initiateMultipart(iocontext));
 }
 
-void HttpIOChain::commitChunks(IOChainContext& iocontext,
+bool HttpIOChain::commitChunks(IOChainContext& iocontext,
                                const std::string &uploadId,
                                const std::vector<std::string> &etags) {
-     CHAIN_FORWARD_VOID(commitChunks(iocontext, uploadId, etags));
+     CHAIN_FORWARD(commitChunks(iocontext, uploadId, etags));
 }
 
 } // Davix

--- a/src/fileops/httpiochain.hpp
+++ b/src/fileops/httpiochain.hpp
@@ -38,14 +38,6 @@ class ContentProvider;
     }while(0)
 
 
-#define CHAIN_FORWARD_VOID(X) \
-        do{ \
-        if(_next.get() != NULL){ \
-            _next->X; return; \
-        } \
-        throw DavixException(davix_scope_io_buff(), StatusCode::OperationNonSupported, "I/O operation not supported"); \
-    }while(0)
-
 // stores state for readToFd operations - necessary, so as not to write the same
 // data again to an fd after a retry / metalink recovery.
 struct FdHandler {
@@ -176,13 +168,13 @@ public:
 
     // Given the upload id and part#, write the given buffer and add the
     // object id to the etags vector.
-    virtual void writeFromBuffer(IOChainContext&  iocontext, const char* buff,
+    virtual bool writeFromBuffer(IOChainContext&  iocontext, const char* buff,
                                  dav_size_t size, const std::string& uploadId,
                                  std::vector<std::string>& etags,
                                  int partNumber);
 
     // Given upload id and list of object tags, commit chunks
-    virtual void commitChunks(IOChainContext& iocontext,
+    virtual bool commitChunks(IOChainContext& iocontext,
                               const std::string &uploadId,
                               const std::vector<std::string> &etags);
 

--- a/src/fileops/httpiochain.hpp
+++ b/src/fileops/httpiochain.hpp
@@ -138,8 +138,8 @@ public:
     virtual dav_ssize_t readToFd(IOChainContext & iocontext, int fd, dav_size_t size);
 
     virtual dav_ssize_t preadVec(IOChainContext & iocontext, const DavIOVecInput * input_vec,
-                             DavIOVecOuput * output_vec,
-                              const dav_size_t count_vec);
+                                 DavIOVecOuput * output_vec,
+                                 const dav_size_t count_vec);
 
     // reset file position and status
     virtual void resetIO(IOChainContext & iocontext);

--- a/src/utils/CompatibilityHacks.cpp
+++ b/src/utils/CompatibilityHacks.cpp
@@ -108,7 +108,8 @@ bool CompatibilityHacks::dynafedAssistedS3Upload(const BackendRequest& originati
 
   // Don't engage if size to upload is less than the specified threshold.
   // Override with 'forceMultiPart' fragment param.
-  if(provider.getSize() < s3SizeThreshold && !uri.fragmentParamExists("forceMultiPart")) {
+  if((uint64_t)provider.getSize() < s3SizeThreshold &&
+     !uri.fragmentParamExists("forceMultiPart")) {
     return false;
   }
 

--- a/src/utils/davix_logger.cpp
+++ b/src/utils/davix_logger.cpp
@@ -26,13 +26,34 @@
 #include <utils/davix_logger.hpp>
 #include <utils/stringutils.hpp>
 
+// This bit of code allows one to set the debug level via an envar when
+// the Davix library is being used via a plugin.
+//
+namespace
+{
+int getTraceValue()
+{
+   const char *dbg = getenv("DAVIX_DEBUG");
+   if (dbg)
+      {char dbgval = tolower(*dbg);
+       if (dbgval == 'c') return DAVIX_LOG_CRITICAL;
+       if (dbgval == 'w') return DAVIX_LOG_WARNING;
+       if (dbgval == 'v') return DAVIX_LOG_VERBOSE;
+       if (dbgval == 'd') return DAVIX_LOG_DEBUG;
+       if (dbgval == 't') return DAVIX_LOG_TRACE;
+       if (dbgval == 'a') return DAVIX_LOG_ALL;
+      }
+   return 0;
+}
+}
+
 #ifdef HAVE_ATOMIC
 #include <atomic>
-static std::atomic<int> internal_log_level(0);
+static std::atomic<int> internal_log_level(getTraceValue());
 static std::atomic<int> internal_log_scope(DAVIX_LOG_SCOPE_ALL);
 #else
 #warning "Setting / getting davix loglevel is not thread-safe!"
-int internal_log_level = 0;
+int internal_log_level = getTraceValue();
 int internal_log_scope = DAVIX_LOG_SCOPE_ALL;
 #endif
 


### PR DESCRIPTION
This minimal pull request allows a client to specify that POSIX write requests should use multipart streaming via an envar DAVPOSIX_MPUPLOAD. If the envar is not set the original code path is used and uploads work just as before. This option is meantto be used by S3 proxy servers that cannot tolerate the creation of an intermediate file on POSIX write uploads.