### PR TITLE
Fix s3 dirlisting to follow the istruncated/nextmarker

### DIFF
--- a/src/fileops/davmeta.cpp
+++ b/src/fileops/davmeta.cpp
@@ -1120,12 +1120,13 @@ void s3_start_listing_query(std::unique_ptr<DirHandle> & handle, Context & conte
 
 
 bool s3_directory_listing(std::unique_ptr<DirHandle> & handle, Context & context, const RequestParams* params, const Uri & uri, const std::string & body, std::string & name_entry, StatInfo & info){
-    if(handle.get() == NULL){
+    if (handle.get() == NULL){
         s3_start_listing_query(handle, context, params, uri, body);
-    }
-    XMLPropParser& parser = *(handle->parser);
-    if (parser.getProperties().size() == 0 && parser.getNextMarker() != "") {
-        s3_start_listing_query(handle, context, params, uri, body);
+    } else {
+        XMLPropParser& parser = *(handle->parser);
+        if (parser.getProperties().empty() && !parser.getNextMarker().empty()) {
+            s3_start_listing_query(handle, context, params, uri, body);
+        }
     }
     return s3_get_next_property(handle, name_entry, info);
 }

--- a/src/xml/davxmlparser.hpp
+++ b/src/xml/davxmlparser.hpp
@@ -103,6 +103,7 @@ public:
     virtual ~ElementsParser(){}
 
     virtual std::deque<FileProperties> & getProperties()=0;
+    virtual std::string getNextMarker() { return "";};
 
 };
 

--- a/src/xml/davxmlparser.hpp
+++ b/src/xml/davxmlparser.hpp
@@ -103,7 +103,7 @@ public:
     virtual ~ElementsParser(){}
 
     virtual std::deque<FileProperties> & getProperties()=0;
-    virtual std::string getNextMarker() { return "";};
+    virtual std::string getNextMarker() { return ""; };
 
 };
 

--- a/src/xml/s3propparser.cpp
+++ b/src/xml/s3propparser.cpp
@@ -200,12 +200,7 @@ struct S3PropParser::Internal{
 
         // IsTruncated
         if( (_s3_listing_mode == S3ListingMode::Hierarchical) && (StrUtil::compare_ncase(istruncated_prop, elem) ==0)){
-            if (current == "True" || current == "true") {
-                istruncated = true;
-            }
-            else {
-                istruncated = false;
-            }
+            istruncated = (current == "True" || current == "true");
         }
 
         // NextMarker
@@ -276,7 +271,7 @@ std::deque<FileProperties> & S3PropParser::getProperties(){
 }
 
 std::string S3PropParser::getNextMarker() {
-    return (d_ptr->istruncated? d_ptr->nextmarker : "");
+    return (d_ptr->istruncated ? d_ptr->nextmarker : "");
 }
 
 

--- a/src/xml/s3propparser.hpp
+++ b/src/xml/s3propparser.hpp
@@ -41,6 +41,7 @@ public:
     virtual ~S3PropParser();
 
     virtual std::deque<FileProperties> & getProperties();
+    virtual std::string getNextMarker();
 
 
 protected:


### PR DESCRIPTION
As describe in issue #122, current s3 dirlisting ignores the istruncated=true and nextmarker in s3 response to listobject. This pull request will fix that issue.