### PR TITLE
Use CMake imported target for threads library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,7 +111,7 @@ target_link_libraries(libdavix
   PRIVATE ${libcurl}
   PUBLIC ${LIBSSL_PKG_LIBRARIES}
          ${LIBXML2_LIBRARIES}
-         ${CMAKE_THREAD_LIBS_INIT}
+         Threads::Threads
          ${CMAKE_DL_LIBS}
          ${UUID_LIBRARIES}
          ${SECURE_TRANSPORT_LIBRARIES}
@@ -152,7 +152,7 @@ target_link_libraries(libdavix_static
   PRIVATE ${libcurl}
   PUBLIC ${LIBSSL_PKG_LIBRARIES}
          ${LIBXML2_LIBRARIES}
-         ${CMAKE_THREAD_LIBS_INIT}
+         Threads::Threads
          ${CMAKE_DL_LIBS}
          ${UUID_LIBRARIES}
          ${SECURE_TRANSPORT_LIBRARIES}

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -28,7 +28,7 @@ set_target_properties(davix_tool PROPERTIES
 ## davix ls cmd line
 add_executable(davix_ls_tool davix_tool_ls_main.cpp)
 
-target_link_libraries(davix_ls_tool davix_tool_lib libdavix ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(davix_ls_tool davix_tool_lib libdavix Threads::Threads)
 set_target_properties(davix_ls_tool PROPERTIES
                                 OUTPUT_NAME "davix-ls")
 
@@ -36,14 +36,14 @@ set_target_properties(davix_ls_tool PROPERTIES
 ## davix get cmd line
 add_executable(davix_get_tool davix_tool_get_main.cpp)
 
-target_link_libraries(davix_get_tool davix_tool_lib libdavix pthread ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(davix_get_tool davix_tool_lib libdavix pthread Threads::Threads)
 set_target_properties(davix_get_tool PROPERTIES
                                 OUTPUT_NAME "davix-get")
 
 ## davix put cmd line
 add_executable(davix_put_tool davix_tool_put_main.cpp)
 
-target_link_libraries(davix_put_tool davix_tool_lib libdavix pthread ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(davix_put_tool davix_tool_lib libdavix pthread Threads::Threads)
 set_target_properties(davix_put_tool PROPERTIES
                                 OUTPUT_NAME "davix-put")
 
@@ -58,7 +58,7 @@ set_target_properties(davix_mkdir_tool PROPERTIES
 ## davix rm cmd line
 add_executable(davix_rm_tool davix_tool_rm_main.cpp)
 
-target_link_libraries(davix_rm_tool davix_tool_lib libdavix ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(davix_rm_tool davix_tool_lib libdavix Threads::Threads)
 set_target_properties(davix_rm_tool PROPERTIES
                                 OUTPUT_NAME "davix-rm")
 

--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -7,7 +7,7 @@ LIST(APPEND src_davix_bench "davix_bench.cpp" "chunk_queue.cpp")
 #include_directories(/usr/include/davix)
 
 add_executable(davix-bench ${src_davix_bench})
-target_link_libraries(davix-bench libdavix ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(davix-bench libdavix Threads::Threads)
 
 function(test_read url opt input)
     add_test(test_bench_read_${url} davix-bench ${opt} ${url} ${input})

--- a/test/slow-unit/CMakeLists.txt
+++ b/test/slow-unit/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(davix-slow-unit-tests
   libdavix
   GTest::GTest
   GTest::Main
-  ${CMAKE_THREAD_LIBS_INIT}
+  Threads::Threads
   ${LIBSSL_PKG_LIBRARIES}
 )
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(davix-unit-tests
   libdavix
   GTest::GTest
   GTest::Main
-  ${CMAKE_THREAD_LIBS_INIT}
+  Threads::Threads
   ${LIBSSL_PKG_LIBRARIES}
 )
 


### PR DESCRIPTION
An imported target is generated by the find_package(Threads) call, as described at https://cmake.org/cmake/help/latest/module/FindThreads.html#imported-targets. Usage of this target fixes the conda-forge distribution when cross-compiling the project, see https://github.com/conda-forge/davix-feedstock/pull/48.