### PR TITLE
feat(s3): support SigV4 header signing for v4 requests

### DIFF
--- a/include/davix/params/davixrequestparams.hpp
+++ b/include/davix/params/davixrequestparams.hpp
@@ -174,6 +174,21 @@ public:
     const bool & getAwsAlternate() const;
 
     ///
+    /// \brief enable SigV4 header signing for S3 v4 requests
+    /// \param header_mode if true, use Authorization header; if false (default), use presigned URLs
+    ///
+    /// Only affects requests where AwsRegion is set. With AwsRegion empty (v2 fallback),
+    /// header signing is always used regardless of this setting.
+    ///
+    void setAwsSigV4HeaderMode(const bool & header_mode);
+    
+    ///
+    /// \brief get whether SigV4 header signing is enabled for v4 requests
+    /// \return true if header mode is enabled, false otherwise
+    ///
+    const bool & getAwsSigV4HeaderMode() const;
+
+    ///
     /// \brief set the secret key for Azure authentication
     /// \param key the secret key
     ///

--- a/include/davix/utils/davix_s3_utils.hpp
+++ b/include/davix/utils/davix_s3_utils.hpp
@@ -33,6 +33,10 @@ Uri signURI(const RequestParams & params, const std::string & method, const Uri 
 
 void signRequest(const RequestParams & params, const std::string & method, const Uri & url, HeaderVec & headers);
 
+// Sign an S3 v4 request in Authorization-header form (does not modify the URI).
+// Respects a caller-provided x-amz-date so signing can be tested deterministically.
+void signRequestv4(const RequestParams & params, const std::string & method, const Uri & url, HeaderVec & headers);
+
 Uri tokenizeRequest(const RequestParams & params, const std::string & method, const Uri & url, HeaderVec & headers, time_t expirationTime);
 
 Uri s3UriTransformer(const Uri & original_url, const RequestParams & params, const bool addDelimiter);

--- a/src/backend/BackendRequest.cpp
+++ b/src/backend/BackendRequest.cpp
@@ -97,15 +97,23 @@ RequestParams& BackendRequest::getParameters() {
 // Configure request for S3.
 //------------------------------------------------------------------------------
 void BackendRequest::configureS3params() {
-  // strange workaround to get S3 compatibility on gcloud to work
   if(_params.getAwsRegion().empty()) {
+    // v2 — always uses header signing.
+    HeaderVec vec = _headers_field;
+    S3::signRequest(_params, _request_type, *_current, vec);
+    vec.swap(_headers_field);
+  }
+  else if(_params.getAwsSigV4HeaderMode()) {
+    // v4 — opt-in header signing.
     HeaderVec vec = _headers_field;
     S3::signRequest(_params, _request_type, *_current, vec);
     vec.swap(_headers_field);
   }
   else {
-    Uri signed_url = S3::signURI(_params, _request_type, *_current, _headers_field, DEFAULT_REQUEST_SIGNING_DURATION);
-    _current= std::shared_ptr<Uri>(new Uri(signed_url));
+    // v4 — default presigned-URL signing.
+    Uri signed_url = S3::signURI(_params, _request_type, *_current,
+                                 _headers_field, DEFAULT_REQUEST_SIGNING_DURATION);
+    _current = std::shared_ptr<Uri>(new Uri(signed_url));
   }
 }
 

--- a/src/params/davixrequestparams.cpp
+++ b/src/params/davixrequestparams.cpp
@@ -100,6 +100,7 @@ struct RequestParamsInternal{
         _aws_region(),
         _aws_token(),
         _aws_alternate(false),
+        _aws_sigv4_header_mode(false),
         _azure_key(),
         _gcloud_creds(),
         _os_token(),
@@ -152,6 +153,7 @@ struct RequestParamsInternal{
         _aws_region(param_private._aws_region),
         _aws_token(param_private._aws_token),
         _aws_alternate(param_private._aws_alternate),
+        _aws_sigv4_header_mode(param_private._aws_sigv4_header_mode),
         _azure_key(param_private._azure_key),
         _gcloud_creds(param_private._gcloud_creds),
         _os_token(param_private._os_token),
@@ -203,6 +205,7 @@ struct RequestParamsInternal{
     AwsRegion _aws_region;
     AwsToken _aws_token;
     bool _aws_alternate;
+    bool _aws_sigv4_header_mode;
     AzureSecretKey _azure_key;
     gcloud::Credentials _gcloud_creds;
     OSToken _os_token;
@@ -399,6 +402,14 @@ void RequestParams::setAwsAlternate(const bool &alternate) {
 
 const bool & RequestParams::getAwsAlternate() const {
     return d_ptr->_aws_alternate;
+}
+
+void RequestParams::setAwsSigV4HeaderMode(const bool & header_mode) {
+    d_ptr->_aws_sigv4_header_mode = header_mode;
+}
+
+const bool & RequestParams::getAwsSigV4HeaderMode() const {
+    return d_ptr->_aws_sigv4_header_mode;
 }
 
 void RequestParams::setAzureKey(const AzureSecretKey &key) {

--- a/src/utils/davix_s3_utils.cpp
+++ b/src/utils/davix_s3_utils.cpp
@@ -33,6 +33,7 @@
 #include "libs/alibxx/crypto/hmacsha.hpp"
 #include <openssl/md5.h>
 #include <sys/mman.h>
+#include <fstream>
 
 template <typename T>
 static inline std::string SSTR(const T& v)
@@ -73,14 +74,12 @@ std::string getAwsAuthorizationField(const std::string & stringToSign, const std
 }
 
 std::string getAwsSignaturev4(const std::string & stringToSign, const std::string & private_key,
-                           const std::string & region, const std::string & service) {
-    const std::string date = current_time("%Y%m%d");
+                              const std::string & region, const std::string & service,
+                              const std::string & date) {
     const std::string kDate = hmac_sha256("AWS4" + private_key, date);
     const std::string kRegion = hmac_sha256(kDate, region);
     const std::string kService = hmac_sha256(kRegion, service);
-
-    const std::string c = "aws4_request";
-    const std::string kSigning = hmac_sha256(kService, c);
+    const std::string kSigning = hmac_sha256(kService, "aws4_request");
     return hexEncode(hmac_sha256(kSigning, stringToSign));
 }
 
@@ -247,12 +246,13 @@ void signRequestv2(const RequestParams & params, const std::string & method, con
 
 
 // Sign an S3 request by modifying the headers, not the URI
-void signRequest(const RequestParams & params, const std::string & method, const Uri & url, HeaderVec & headers){
+void signRequest(const RequestParams & params, const std::string & method,
+                 const Uri & url, HeaderVec & headers){
     if(params.getAwsRegion().empty()) {
         signRequestv2(params, method, url, headers);
     }
     else {
-        throw std::runtime_error("v4 header signing not yet implemented");
+        signRequestv4(params, method, url, headers);
     }
 }
 
@@ -371,7 +371,7 @@ Uri signURIv4(const RequestParams & params, const std::string & method, const Ur
     Uri signedUrl = url;
 
     std::string signature = getAwsSignaturev4(stringToSign.str(), params.getAwsAutorizationKeys().first,
-                                              params.getAwsRegion(), "s3");
+                                              params.getAwsRegion(), "s3", current_time("%Y%m%d"));
 
     DAVIX_SLOG(DAVIX_LOG_VERBOSE, DAVIX_LOG_S3, "Signature: {}", signature);
     signedUrl.addQueryParam("X-Amz-Signature", signature);
@@ -385,6 +385,164 @@ Uri signURIv4(const RequestParams & params, const std::string & method, const Ur
     DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_S3, "Signed URL: {}", signedUrl);
     return signedUrl;
 }
+
+
+void signRequestv4(const RequestParams & params, const std::string & method,
+                   const Uri & url, HeaderVec & headers) {
+    // references
+    // https://docs.aws.amazon.com/AmazonS3/latest/developerguide/sigv4-auth-using-authorization-header.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/developerguide/sig-v4-header-based-auth.html
+    // http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+    DAVIX_SLOG(DAVIX_LOG_VERBOSE, DAVIX_LOG_S3,
+               "Using S3 v4 signature authentication (header mode)");
+
+    // timestamps — respect a caller-supplied x-amz-date (test seam); otherwise
+    // generate. datestamp is derived from whichever amzdate we end up using.
+    std::string amzdate;
+    for(const auto & h : headers) {
+        if(StrUtil::compare_ncase(h.first, "x-amz-date") == 0) {
+            amzdate = h.second;
+            break;
+        }
+    }
+    if(amzdate.empty()) {
+        amzdate = current_time("%Y%m%dT%H%M%SZ");
+        headers.push_back(HeaderLine("x-amz-date", amzdate));
+    }
+    // x-amz-date is YYYYMMDDTHHMMSSZ (16 chars); datestamp is the YYYYMMDD prefix.
+    if(amzdate.size() < 16) {
+        throw DavixException(std::string("S3::signRequestv4"), StatusCode::InvalidArgument,
+                             "Malformed x-amz-date: " + amzdate);
+    }
+    const std::string datestamp = amzdate.substr(0, 8);
+
+    // payload hash: for bodyless verbs sign SHA256("") rather than the
+    // "UNSIGNED-PAYLOAD" literal — strict gateways (Copernicus gateway) 403 on a
+    // signed UNSIGNED-PAYLOAD against an empty body. SHA256("") = e3b0c442...
+    //
+    // NOTE: streaming/multipart uploads (STREAMING-AWS4-HMAC-SHA256-PAYLOAD) are
+    // not implemented; PUT/POST use UNSIGNED-PAYLOAD.
+    static const std::string EMPTY_SHA256 =
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    const bool bodyless =
+        (method == "GET" || method == "HEAD" || method == "DELETE");
+    const std::string payload_hash =
+        bodyless ? EMPTY_SHA256 : std::string("UNSIGNED-PAYLOAD");
+
+    // add content-sha256 only if not already present (dedup)
+    bool has_content_sha = false;
+    for(const auto & h : headers) {
+        if(StrUtil::compare_ncase(h.first, "x-amz-content-sha256") == 0) {
+            has_content_sha = true;
+            break;
+        }
+    }
+    if(!has_content_sha) {
+        headers.push_back(HeaderLine("x-amz-content-sha256", payload_hash));
+    }
+    if(params.getAwsToken().size() != 0) {
+        headers.push_back(HeaderLine("x-amz-security-token", params.getAwsToken()));
+    }
+
+    // host (omit default port)
+    bool defaultPort = (url.getPort() == 0)
+        || (url.getPort() == 80  && (url.getProtocol() == "http"  || url.getProtocol() == "s3"))
+        || (url.getPort() == 443 && (url.getProtocol() == "https" || url.getProtocol() == "s3s"));
+    std::string host = url.getHost();
+    if(!defaultPort) host += SSTR(":" << url.getPort());
+
+    // canonical headers: getAmzCanonHeaders_vec returns the x-amz-* headers
+    // (original-case) but NOT host or x-amz-date, so add those explicitly.
+    // Also add any signed non-amz headers the caller set (e.g. Range). The dedup
+    // below makes these explicit pushes safe even if a header is also present in
+    // the vector returned by getAmzCanonHeaders_vec.
+    HeaderVec can_headers = getAmzCanonHeaders_vec(headers);
+    can_headers.push_back(HeaderLine("host", host));
+    can_headers.push_back(HeaderLine("x-amz-date", amzdate));
+
+    // include "range" if supplied (AWS example signs host;range;...sha256;date)
+    for(const auto & h : headers) {
+        if(StrUtil::compare_ncase(h.first, "range") == 0) {
+            can_headers.push_back(HeaderLine("range", h.second));
+        }
+    }
+
+    // lowercase keys, then sort, then dedup by key
+    for(auto & h : can_headers) h.first = StrUtil::toLower(h.first);
+    std::sort(can_headers.begin(), can_headers.end());
+    // Dedup by header key (keeps first value). NOTE: we do not combine duplicate
+    // signed headers into a comma-separated value as AWS canonicalization allows;
+    // davix does not emit duplicate signed headers in practice.
+    can_headers.erase(
+        std::unique(can_headers.begin(), can_headers.end(),
+                    [](const HeaderLine & a, const HeaderLine & b){
+                        return a.first == b.first;
+                    }),
+        can_headers.end());
+
+    std::ostringstream can_headers_str, signed_headers_str;
+    for(auto it = can_headers.begin(); it != can_headers.end(); ++it) {
+        can_headers_str << it->first << ":" << StrUtil::trim(it->second) << "\n";
+        signed_headers_str << it->first;
+        if(it + 1 != can_headers.end()) signed_headers_str << ";";
+    }
+
+    // canonical query string: getQueryVec() returns decoded values; pass them
+    // through unescaped to match signURIv4 (do not double-encode).
+    ParamVec can_query_params;
+    const ParamVec existing_params = url.getQueryVec();
+    for(const auto & p : existing_params) {
+        can_query_params.push_back(ParamLine(p.first, p.second));
+    }
+    std::sort(can_query_params.begin(), can_query_params.end());
+
+    std::ostringstream can_query_str;
+    for(auto it = can_query_params.begin(); it != can_query_params.end(); ++it) {
+        can_query_str << it->first << "=" << it->second;
+        if(it + 1 != can_query_params.end()) can_query_str << "&";
+    }
+
+    // canonical request
+    std::ostringstream canonical_request;
+    canonical_request << method << "\n"
+                      << url.getPath() << "\n"
+                      << can_query_str.str() << "\n"
+                      << can_headers_str.str() << "\n"
+                      << signed_headers_str.str() << "\n"
+                      << payload_hash;
+
+    DAVIX_SLOG(DAVIX_LOG_DEBUG, DAVIX_LOG_S3,
+               "Canonical request (header mode) length: {}",
+               canonical_request.str().size());
+
+    // string to sign
+    const std::string can_req_hash = hexEncode(sha256(canonical_request.str().c_str()));
+    std::ostringstream string_to_sign;
+    string_to_sign << "AWS4-HMAC-SHA256" << "\n"
+                   << amzdate << "\n"
+                   << datestamp << "/" << params.getAwsRegion() << "/s3/aws4_request" << "\n"
+                   << can_req_hash;
+
+    // signature
+    const std::string signature = getAwsSignaturev4(string_to_sign.str(), params.getAwsAutorizationKeys().first,
+                                                    params.getAwsRegion(), "s3", datestamp);
+
+    DAVIX_SLOG(DAVIX_LOG_VERBOSE, DAVIX_LOG_S3, "Signature: {}", signature);
+
+    // Authorization header
+    std::ostringstream auth;
+    auth << "AWS4-HMAC-SHA256 "
+         << "Credential=" << params.getAwsAutorizationKeys().second
+                          << "/" << datestamp
+                          << "/" << params.getAwsRegion()
+                          << "/s3/aws4_request, "
+         << "SignedHeaders=" << signed_headers_str.str() << ", "
+         << "Signature=" << signature;
+
+    headers.push_back(HeaderLine("Authorization", auth.str()));
+}
+
 
 // return a signed s3 URI, does not modify the headers
 Uri signURI(const RequestParams & params, const std::string & method, const Uri & url, HeaderVec headers, const time_t expirationTime) {

--- a/test/unit/utils.cpp
+++ b/test/unit/utils.cpp
@@ -275,3 +275,140 @@ TEST(HeaderlineParser, BasicSanity) {
     ASSERT_EQ(parser.getKey(), "aaa");
     ASSERT_EQ(parser.getValue(), "bbb");
 }
+
+// GOLDEN VECTOR — exact-match against AWS's published "GET Object" example.
+//
+// Source: AWS S3 Developer Guide, "Signature Calculations for the Authorization
+// Header: Transferring Payload in a Single Chunk (AWS Signature Version 4)",
+// Example: GET Object. Inputs and expected outputs are copied verbatim from
+// that page. The expected signature is AWS's, not ours: if this test fails,
+// fix the signer, never edit the expected value.
+//
+//   GET https://examplebucket.s3.amazonaws.com/test.txt
+//   Range: bytes=0-9
+//   x-amz-date: 20130524T000000Z   (pinned via the date seam)
+//   region us-east-1, empty payload (x-amz-content-sha256 = SHA256(""))
+//   SignedHeaders = host;range;x-amz-content-sha256;x-amz-date
+TEST(testAuthS3, ReqToSignV4GoldenVector){
+    RequestParams params;
+    Uri url("https://examplebucket.s3.amazonaws.com/test.txt");
+    ASSERT_EQ(url.getPath(), "/test.txt") << "path is: [" << url.getPath() << "]";
+    params.setAwsAuthorizationKeys(
+        "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "AKIAIOSFODNN7EXAMPLE");
+    params.setAwsRegion("us-east-1");
+
+    HeaderVec vec;
+    // Pin the date (test seam) and supply Range exactly as the AWS example does.
+    vec.push_back(HeaderLine("x-amz-date", "20130524T000000Z"));
+    vec.push_back(HeaderLine("Range", "bytes=0-9"));
+
+    S3::signRequest(params, "GET", url, vec);
+
+    std::string auth;
+    for(const auto& h : vec) {
+        if(StrUtil::compare_ncase(h.first, "Authorization") == 0) auth = h.second;
+    }
+    ASSERT_FALSE(auth.empty()) << "no Authorization header produced";
+
+    // Structural: exact SignedHeaders set & order, and credential scope.
+    ASSERT_NE(auth.find("SignedHeaders=host;range;x-amz-content-sha256;x-amz-date"),
+              std::string::npos) << "Authorization was: " << auth;
+    ASSERT_NE(auth.find("Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request"),
+              std::string::npos) << "Authorization was: " << auth;
+
+    // EXACT signature from AWS's published GET Object example.
+    const std::string AWS_EXPECTED_SIGNATURE =
+        "Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41";
+    ASSERT_NE(auth.find(AWS_EXPECTED_SIGNATURE), std::string::npos)
+        << "Signature mismatch — signer is wrong, do not edit the expected value.\n"
+        << "Authorization was: " << auth;
+
+    // Full Authorization header AWS publishes for this example (belt-and-suspenders).
+    const std::string AWS_EXPECTED_AUTH =
+        "AWS4-HMAC-SHA256 "
+        "Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, "
+        "SignedHeaders=host;range;x-amz-content-sha256;x-amz-date, "
+        "Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41";
+    ASSERT_EQ(auth, AWS_EXPECTED_AUTH)
+        << "Full Authorization header does not match AWS's published value.";
+}
+
+// Determinism: same pinned inputs -> identical signature on repeated calls.
+// (Catches accidental nondeterminism in canonicalization.)
+TEST(testAuthS3, ReqToSignV4Deterministic){
+    auto sign_once = [](){
+        RequestParams params;
+        Uri url("https://examplebucket.s3.amazonaws.com/test.txt");
+        params.setAwsAuthorizationKeys(
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "AKIAIOSFODNN7EXAMPLE");
+        params.setAwsRegion("us-east-1");
+        HeaderVec vec;
+        vec.push_back(HeaderLine("x-amz-date", "20130524T000000Z"));
+        S3::signRequest(params, "GET", url, vec);
+        for(const auto& h : vec)
+            if(StrUtil::compare_ncase(h.first, "Authorization") == 0) return h.second;
+        return std::string();
+    };
+    ASSERT_EQ(sign_once(), sign_once());
+}
+
+// A caller-supplied x-amz-date / x-amz-content-sha256
+// must not appear twice in SignedHeaders.
+TEST(testAuthS3, ReqToSignV4NoDuplicateSignedHeaders){
+    RequestParams params;
+    Uri url("https://examplebucket.s3.amazonaws.com/test.txt");
+    params.setAwsAuthorizationKeys(
+        "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "AKIAIOSFODNN7EXAMPLE");
+    params.setAwsRegion("us-east-1");
+
+    HeaderVec vec;
+    vec.push_back(HeaderLine("x-amz-date", "20130524T000000Z"));
+    vec.push_back(HeaderLine("x-amz-content-sha256",
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+
+    S3::signRequest(params, "GET", url, vec);
+
+    std::string auth;
+    for(const auto& h : vec)
+        if(StrUtil::compare_ncase(h.first, "Authorization") == 0) auth = h.second;
+
+    // "x-amz-date" / "x-amz-content-sha256" must appear exactly once in SignedHeaders.
+    const std::string sh_key = "SignedHeaders=";
+    auto sh_pos = auth.find(sh_key);
+    ASSERT_NE(sh_pos, std::string::npos);
+    auto sh_end = auth.find(',', sh_pos);
+    const std::string signed_list = auth.substr(sh_pos, sh_end - sh_pos);
+
+    auto count_occurrences = [&](const std::string& needle){
+        size_t n = 0, p = 0;
+        while((p = signed_list.find(needle, p)) != std::string::npos){ ++n; p += needle.size(); }
+        return n;
+    };
+    ASSERT_EQ(count_occurrences("x-amz-date"), 1u);
+    ASSERT_EQ(count_occurrences("x-amz-content-sha256"), 1u);
+}
+
+// Verb behaviour: bodyless verbs sign the empty-SHA256; PUT signs
+// UNSIGNED-PAYLOAD. Assert the x-amz-content-sha256 header reflects this.
+TEST(testAuthS3, ReqToSignV4PayloadHashByVerb){
+    auto content_sha = [](const std::string& verb){
+        RequestParams params;
+        Uri url("https://examplebucket.s3.amazonaws.com/test.txt");
+        params.setAwsAuthorizationKeys(
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "AKIAIOSFODNN7EXAMPLE");
+        params.setAwsRegion("us-east-1");
+        HeaderVec vec;
+        vec.push_back(HeaderLine("x-amz-date", "20130524T000000Z"));
+        S3::signRequest(params, verb, url, vec);
+        for(const auto& h : vec)
+            if(StrUtil::compare_ncase(h.first, "x-amz-content-sha256") == 0) return h.second;
+        return std::string();
+    };
+    const std::string EMPTY_SHA256 =
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    ASSERT_EQ(content_sha("GET"), EMPTY_SHA256);
+    ASSERT_EQ(content_sha("HEAD"), EMPTY_SHA256);
+    ASSERT_EQ(content_sha("DELETE"), EMPTY_SHA256);
+    ASSERT_EQ(content_sha("PUT"), std::string("UNSIGNED-PAYLOAD"));
+}


### PR DESCRIPTION
Closes: #149

---

Reviewer/s: @joaopblopes, @andrea-manzi

Following the discussion with Andrea and Joao regarding the addition of AWS SigV4 header signing for RI-SCALE (Copernicus Data Space interop), either would be suitable to review.